### PR TITLE
Fix: Ammo crate explosiveness

### DIFF
--- a/lua/acf/server/sv_acfdamage.lua
+++ b/lua/acf/server/sv_acfdamage.lua
@@ -326,8 +326,25 @@ end
 
 function ACF_AmmoExplosion( Origin , Pos )
 
-	local HEWeight = Origin.Ammo/2
+	--old method, purely based on ammo count
+	--local HEWeight = Origin.Ammo/2
+	
+	--treats propellant as 1x the explosive power of TNT
+	--local BoomPower = Origin.BulletData["BoomPower"]
+	--if not BoomPower then BoomPower = 0.002 end --make sure refills are explosive
+	--local HEWeight = BoomPower * Origin.Ammo
+	
+	--treats propellant as ~1/8x the explosive power of TNT
+	local HEContent, PropContent
+	if Origin.RoundType == "Refill" then
+		HEContent = 0.001
+		PropContent = 0.001
+	else 
+		HEContent = Origin.BulletData["FillerMass"] or 0
+		PropContent = Origin.BulletData["PropMass"] or 0
+	end
 	local LastHE = 0
+	local HEWeight = (HEContent+PropContent*(ACF.PBase/ACF.HEPower))*Origin.Ammo
 	local Power = HEWeight * ACF.HEPower					--Power in KiloJoules of the filler mass of  TNT 
 	local Radius = (HEWeight)^0.33*8*39.37				--Scalling law found on the net, based on 1PSI overpressure from 1 kg of TNT at 15m
 	local Search = true

--- a/lua/entities/acf_ammo/init.lua
+++ b/lua/entities/acf_ammo/init.lua
@@ -259,22 +259,24 @@ function ENT:Think()
 		if self.Damaged < CurTime() then
 			ACF_AmmoExplosion( self.Entity , self.Entity:GetPos() )
 		else
-			if math.Rand(0,150) > self.BulletData["RoundVolume"]^0.5 and math.Rand(0,1) < self.Ammo/math.max(self.Capacity,1) and ACF.RoundTypes[self.BulletData["Type"]] then
-				self.Entity:EmitSound( "ambient/explosions/explode_4.wav" , 350 , math.max(255 - self.BulletData["PropMass"]*100,60)  )	
-				local MuzzlePos = self.Entity:GetPos()
-				local MuzzleVec = VectorRand()
-				local Speed = ACF_MuzzleVelocity( self.BulletData["PropMass"], self.BulletData["ProjMass"]/2, self.Caliber )
-				
-				self.BulletData["Pos"] = MuzzlePos
-				self.BulletData["Flight"] = (MuzzleVec):GetNormalized() * Speed * 39.37 + self:GetVelocity()
-				self.BulletData["Owner"] = self.Inflictor or self.Owner
-				self.BulletData["Gun"] = self.Entity
-				self.BulletData["Crate"] = self.Entity:EntIndex()
-				self.CreateShell = ACF.RoundTypes[self.BulletData["Type"]]["create"]
-				self:CreateShell( self.BulletData )
-				
-				self.Ammo = self.Ammo - 1
-				
+			if not self.BulletData["Type"] == "Refill" then
+				if math.Rand(0,150) > self.BulletData["RoundVolume"]^0.5 and math.Rand(0,1) < self.Ammo/math.max(self.Capacity,1) and ACF.RoundTypes[self.BulletData["Type"]] then
+					self.Entity:EmitSound( "ambient/explosions/explode_4.wav" , 350 , math.max(255 - self.BulletData["PropMass"]*100,60)  )	
+					local MuzzlePos = self.Entity:GetPos()
+					local MuzzleVec = VectorRand()
+					local Speed = ACF_MuzzleVelocity( self.BulletData["PropMass"], self.BulletData["ProjMass"]/2, self.Caliber )
+					
+					self.BulletData["Pos"] = MuzzlePos
+					self.BulletData["Flight"] = (MuzzleVec):GetNormalized() * Speed * 39.37 + self:GetVelocity()
+					self.BulletData["Owner"] = self.Inflictor or self.Owner
+					self.BulletData["Gun"] = self.Entity
+					self.BulletData["Crate"] = self.Entity:EntIndex()
+					self.CreateShell = ACF.RoundTypes[self.BulletData["Type"]]["create"]
+					self:CreateShell( self.BulletData )
+					
+					self.Ammo = self.Ammo - 1
+					
+				end
 			end
 			self.Entity:NextThink( CurTime() + 0.01 + self.BulletData["RoundVolume"]^0.5/100 )
 		end


### PR DESCRIPTION
Ammo crate explosion power is now determined by how much explosive content is inside the crate, rather than purely on ammo count. Generally, expect less boom from smaller rounds, and more boom from big rounds.

This may needs a bit of balance checking before being merged, as it seems crate explosions from large weapons are more potent.

Fixes Issue #12
