### PR TITLE
Changed CVT behaviour, far less annoying sound

### DIFF
--- a/lua/acf/shared/gearboxes/cvt.lua
+++ b/lua/acf/shared/gearboxes/cvt.lua
@@ -12,7 +12,7 @@ local GearCVTMT = 340
 local GearCVTLT = 3200
 
 -- general description
-local CVTDesc = "\n\nA CVT will adjust the ratio of gear 1 to keep the engine at the desired RPM, allowing constant peak performance. However, this comes at the cost of increased weight and limited torque ratings."
+local CVTDesc = "\n\nA CVT will adjust the ratio its first gear to keep an engine within a target rpm range, allowing constant peak performance. However, this comes at the cost of increased weight and limited torque ratings."
 
 -- Inline
 
@@ -27,8 +27,9 @@ ACF_DefineGearbox( "CVT-L-S", {
 	gears = 2,
 	cvt = true,
 	geartable = {
-        [-2] = 5000, --target rpm slider
-		[-1] = 0.5, --final drive
+		[-3] = 3000, --target min rpm
+        [-2] = 5000, --target max rpm
+		[-1] = 1, --final drive
 		[ 0 ] = 0,
 		[ 1 ] = 0,
 		[ 2 ] = -0.1
@@ -46,8 +47,9 @@ ACF_DefineGearbox( "CVT-L-M", {
 	gears = 2,
 	cvt = true,
 	geartable = {
-        [-2] = 5000, --target rpm slider
-		[-1] = 0.5, --final drive
+		[-3] = 3000, --target min rpm
+        [-2] = 5000, --target max rpm
+		[-1] = 1, --final drive
 		[ 0 ] = 0,
 		[ 1 ] = 0,
 		[ 2 ] = -0.1
@@ -65,8 +67,9 @@ ACF_DefineGearbox( "CVT-L-L", {
 	gears = 2,
 	cvt = true,
 	geartable = {
-        [-2] = 5000, --target rpm slider
-		[-1] = 0.5, --final drive
+		[-3] = 3000, --target min rpm
+        [-2] = 5000, --target max rpm
+		[-1] = 1, --final drive
 		[ 0 ] = 0,
 		[ 1 ] = 0,
 		[ 2 ] = -0.1
@@ -87,8 +90,9 @@ ACF_DefineGearbox( "CVT-LD-S", {
 	doubleclutch = true,
 	cvt = true,
 	geartable = {
-        [-2] = 5000, --target rpm slider
-		[-1] = 0.5, --final drive
+		[-3] = 3000, --target min rpm
+        [-2] = 5000, --target max rpm
+		[-1] = 1, --final drive
 		[ 0 ] = 0,
 		[ 1 ] = 0,
 		[ 2 ] = -0.1
@@ -107,8 +111,9 @@ ACF_DefineGearbox( "CVT-LD-M", {
 	doubleclutch = true,
 	cvt = true,
 	geartable = {
-        [-2] = 5000, --target rpm slider
-		[-1] = 0.5, --final drive
+		[-3] = 3000, --target min rpm
+        [-2] = 5000, --target max rpm
+		[-1] = 1, --final drive
 		[ 0 ] = 0,
 		[ 1 ] = 0,
 		[ 2 ] = -0.1
@@ -127,8 +132,9 @@ ACF_DefineGearbox( "CVT-LD-L", {
 	doubleclutch = true,
 	cvt = true,
 	geartable = {
-        [-2] = 5000, --target rpm slider
-		[-1] = 0.5, --final drive
+		[-3] = 3000, --target min rpm
+        [-2] = 5000, --target max rpm
+		[-1] = 1, --final drive
 		[ 0 ] = 0,
 		[ 1 ] = 0,
 		[ 2 ] = -0.1
@@ -148,8 +154,9 @@ ACF_DefineGearbox( "CVT-T-S", {
 	gears = 2,
 	cvt = true,
 	geartable = {
-        [-2] = 5000, --target rpm slider
-		[-1] = 0.5, --final drive
+		[-3] = 3000, --target min rpm
+        [-2] = 5000, --target max rpm
+		[-1] = 1, --final drive
 		[ 0 ] = 0,
 		[ 1 ] = 0,
 		[ 2 ] = -0.1
@@ -167,8 +174,9 @@ ACF_DefineGearbox( "CVT-T-M", {
 	gears = 2,
 	cvt = true,
 	geartable = {
-        [-2] = 5000, --target rpm slider
-		[-1] = 0.5, --final drive
+		[-3] = 3000, --target min rpm
+        [-2] = 5000, --target max rpm
+		[-1] = 1, --final drive
 		[ 0 ] = 0,
 		[ 1 ] = 0,
 		[ 2 ] = -0.1
@@ -186,8 +194,9 @@ ACF_DefineGearbox( "CVT-T-L", {
 	gears = 2,
 	cvt = true,
 	geartable = {
-        [-2] = 5000, --target rpm slider
-		[-1] = 0.5, --final drive
+		[-3] = 3000, --target min rpm
+        [-2] = 5000, --target max rpm
+		[-1] = 1, --final drive
 		[ 0 ] = 0,
 		[ 1 ] = 0,
 		[ 2 ] = -0.1
@@ -208,8 +217,9 @@ ACF_DefineGearbox( "CVT-TD-S", {
 	doubleclutch = true,
 	cvt = true,
 	geartable = {
-        [-2] = 5000, --target rpm slider
-		[-1] = 0.5, --final drive
+		[-3] = 3000, --target min rpm
+        [-2] = 5000, --target max rpm
+		[-1] = 1, --final drive
 		[ 0 ] = 0,
 		[ 1 ] = 0,
 		[ 2 ] = -0.1
@@ -228,8 +238,9 @@ ACF_DefineGearbox( "CVT-TD-M", {
 	doubleclutch = true,
 	cvt = true,
 	geartable = {
-        [-2] = 5000, --target rpm slider
-		[-1] = 0.5, --final drive
+		[-3] = 3000, --target min rpm
+        [-2] = 5000, --target max rpm
+		[-1] = 1, --final drive
 		[ 0 ] = 0,
 		[ 1 ] = 0,
 		[ 2 ] = -0.1
@@ -248,8 +259,9 @@ ACF_DefineGearbox( "CVT-TD-L", {
 	doubleclutch = true,
 	cvt = true,
 	geartable = {
-        [-2] = 5000, --target rpm slider
-		[-1] = 0.5, --final drive
+		[-3] = 3000, --target min rpm
+        [-2] = 5000, --target max rpm
+		[-1] = 1, --final drive
 		[ 0 ] = 0,
 		[ 1 ] = 0,
 		[ 2 ] = -0.1
@@ -269,8 +281,9 @@ ACF_DefineGearbox( "CVT-ST-S", {
 	gears = 2,
 	cvt = true,
 	geartable = {
-        [-2] = 5000, --target rpm slider
-		[-1] = 0.5, --final drive
+		[-3] = 3000, --target min rpm
+        [-2] = 5000, --target max rpm
+		[-1] = 1, --final drive
 		[ 0 ] = 0,
 		[ 1 ] = 0,
 		[ 2 ] = -0.1
@@ -288,8 +301,9 @@ ACF_DefineGearbox( "CVT-ST-M", {
 	gears = 2,
 	cvt = true,
 	geartable = {
-        [-2] = 5000, --target rpm slider
-		[-1] = 0.5, --final drive
+		[-3] = 3000, --target min rpm
+        [-2] = 5000, --target max rpm
+		[-1] = 1, --final drive
 		[ 0 ] = 0,
 		[ 1 ] = 0,
 		[ 2 ] = -0.1
@@ -307,8 +321,9 @@ ACF_DefineGearbox( "CVT-ST-L", {
 	gears = 2,
 	cvt = true,
 	geartable = {
-        [-2] = 5000, --target rpm slider
-		[-1] = 0.5, --final drive
+		[-3] = 3000, --target min rpm
+        [-2] = 5000, --target max rpm
+		[-1] = 1, --final drive
 		[ 0 ] = 0,
 		[ 1 ] = 0,
 		[ 2 ] = -0.1

--- a/lua/entities/acf_gearbox/cl_init.lua
+++ b/lua/entities/acf_gearbox/cl_init.lua
@@ -34,8 +34,9 @@ function ENT:GetOverlayText()
 	txt = txt .. "Final Drive: " .. tostring( fd ) .. "\n"
 	
 	if cvt == 1 then
-		local targetrpm = self:GetNetworkedBeamInt( "TargetRPM" )
-		txt = txt.."Target Input RPM: " .. tostring( targetrpm ) .. "\n"
+		local targetminrpm = self:GetNetworkedBeamInt( "TargetMinRPM" )
+		local targetmaxrpm = self:GetNetworkedBeamInt( "TargetMaxRPM" )
+		txt = txt.."Min Target RPM: " .. tostring( targetminrpm ) .. "\nMax Target RPM: " .. tostring( targetmaxrpm ) .. "\n"
 	end
 	
 	local maxtq = List["Mobility"][id]["maxtq"]
@@ -80,7 +81,8 @@ function ACFGearboxGUICreate( Table )
 	
 	if (acfmenupanel.GearboxData[Table.id]["GearTable"][-2] or 0) != 0 then
 		ACF_GearsSlider(2, acfmenupanel.GearboxData[Table.id]["GearTable"][2], Table.id)
-		ACF_GearsSlider(9, acfmenupanel.GearboxData[Table.id]["GearTable"][-2], Table.id, "Target Input RPM")
+		ACF_GearsSlider(3, acfmenupanel.GearboxData[Table.id]["GearTable"][-3], Table.id, "Min Target RPM",true)
+		ACF_GearsSlider(4, acfmenupanel.GearboxData[Table.id]["GearTable"][-2], Table.id, "Max Target RPM",true)
 		ACF_GearsSlider(10, acfmenupanel.GearboxData[Table.id]["GearTable"][-1], Table.id, "Final Drive")
 		RunConsoleCommand( "acfmenu_data1", 0.01 )
 	else
@@ -101,10 +103,9 @@ function ACFGearboxGUICreate( Table )
 	maxtorque = Table.maxtq
 end
 
-function ACF_GearsSlider(Gear, Value, ID, Desc)
+function ACF_GearsSlider(Gear, Value, ID, Desc, CVT)
 
 	if Gear and not acfmenupanel["CData"][Gear] then	
-		local CVT = Gear == 9
 		acfmenupanel["CData"][Gear] = vgui.Create( "DNumSlider", acfmenupanel.CustomDisplay )
 			acfmenupanel["CData"][Gear]:SetText( Desc or "Gear "..Gear )
 			acfmenupanel["CData"][Gear]:SetDark( true )


### PR DESCRIPTION
 "Want to hear the most annoying sound in the world?" _Jim Carrey imitates a wankel running on a cvt_  
...Yeah, that's fixed now.

CVT now has a target rpm range, instead of a single rpm.  This lets the engine rpm vary with speed, so you don't have to listen to a single monotonous tone for 5 minutes straight.  Also results in a slightly faster response time.
