### PR TITLE
Fix: Typo in e2 funcs, CVT jump

### DIFF
--- a/lua/autorun/acf_globals.lua
+++ b/lua/autorun/acf_globals.lua
@@ -2,7 +2,7 @@ ACF = {}
 ACF.AmmoTypes = {}
 ACF.MenuFunc = {}
 ACF.AmmoBlacklist = {}
-ACF.Version = 356 -- Make sure to change this as the version goes up or the update check is for nothing! -wrex
+ACF.Version = 357 -- Make sure to change this as the version goes up or the update check is for nothing! -wrex
 ACF.CurrentVersion = 0 -- just defining a variable, do not change
 
 ACF.Threshold = 225	--Health Divisor

--- a/lua/entities/acf_gearbox/init.lua
+++ b/lua/entities/acf_gearbox/init.lua
@@ -389,7 +389,7 @@ function ENT:Calc( InputRPM, InputInertia )
 			end
 		
             if self.CVT and self.Gear == 1 then
-                self.GearTable[1] = math.Clamp((InputRPM - self.TargetMinRPM) / ((self.TargetMaxRPM - self.TargetMinRPM) or 1),0.01,1)
+                self.GearTable[1] = math.Clamp((InputRPM - self.TargetMinRPM) / ((self.TargetMaxRPM - self.TargetMinRPM) or 1),0.05,1)
                 self.GearRatio = (self.GearTable[1] or 0)*self.GearTable["Final"]
                 Wire_TriggerOutput(self.Entity, "Ratio", self.GearRatio)
             end

--- a/lua/entities/gmod_wire_expression2/core/custom/acffunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/acffunctions.lua
@@ -352,7 +352,7 @@ e2function void entity:acfClutchRight( number clutch )
 	if not isGearbox(this) then return end
 	if not isOwner(self, this) then return end
 	if (not this.Dual) then return end
-	this:TriggerInput("Right Clutch", Clutch)
+	this:TriggerInput("Right Clutch", clutch)
 end
 
 


### PR DESCRIPTION
-entity:acfClutchRight() no longer causes errors
-CVTs should no longer cause high torque contraptions to jump when throttle is applied (changed gear 1 min ratio from 0.01 to 0.05)
