### PR TITLE
Fixed permissions for starfall functions

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/acffunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/acffunctions.lua
@@ -1,5 +1,5 @@
 E2Lib.RegisterExtension("acf", true)
-CreateConVar("sbox_acf_e2restrictinfo", 1) -- 0=any, 1=owned
+CreateConVar("sbox_acf_restrictinfo", 1) -- 0=any, 1=owned
 -- [ To Do ] --
 
 -- #general

--- a/lua/starfall/libs_sv/acffunctions.lua
+++ b/lua/starfall/libs_sv/acffunctions.lua
@@ -1,4 +1,4 @@
-CreateConVar("sbox_acf_sfrestrictinfo", 1) -- 0=any, 1=owned
+CreateConVar("sbox_acf_restrictinfo", 1) -- 0=any, 1=owned
 -- [ To Do ] --
 
 -- #general


### PR DESCRIPTION
The integrated starfall permissions were not working properly, so I created a convar, "sbox_acf_sfrestrictinfo", for restricting info, the same method used for controlling E2 permissions.

Maybe make it into one convar, "sbox_acf_restrictinfo", being both do the same thing?
