### PR TITLE
entity:acfLinkToAmmoBox and entity:acfUnlinkFromAmmoBox

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/acffunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/acffunctions.lua
@@ -173,6 +173,34 @@ end
 
 __e2setcost( 2 )
 
+e2function number entity:acfLinkToAmmoBox(entity box, number notify)
+    if not isAmmo(box) then return 0 end
+    if not isGun(this) then return 0 end
+
+    if not isOwner(self, this) then return 0 end
+    if not isOwner(self, box) then return 0 end
+    
+    local success, msg = this:Link(box)
+    if notify > 0 then
+        ACF_SendNotify(self.player, success, msg)
+    end
+    return success and 1 or 0
+end
+
+e2function number entity:acfUnlinkFromAmmoBox(entity box, number notify)
+    if not isAmmo(box) then return 0 end
+    if not isGun(this) then return 0 end
+    
+    if not isOwner(self, this) then return 0 end
+    if not isOwner(self, box) then return 0 end
+    
+    local success, msg = this:Unlink(box)
+    if notify > 0 then
+        ACF_SendNotify(self.player, success, msg)
+    end
+    return success and 1 or 0
+end
+
 -- Returns the full name of an ACF entity
 e2function string entity:acfName()
 	if isAmmo(this) then return (this.RoundId .. " " .. this.RoundType) end


### PR DESCRIPTION
I'm sorry, I'm not used to github. I don't know how to edit multiple files but my suggestion is to add these two functions, they're tested on Social Players server.
The function description code:
```
E2Helper.Descriptions["acfLinkToAmmoBox"] = "Links ACF weapon to ammo box. If notify is higher than zero, a notification will be sent when the weapon has been linked. Returns 1 if it linked successfully, otherwise returns 0."
E2Helper.Descriptions["acfUnlinkFromAmmoBox"] = "Unlinks ACF weapon from ammo box. If notify is higher than zero, a notification will be sent when the weapon has been unlinked. Returns 1 if it was unlinked successfully, otherwise returns 0"
```