### PR TITLE
Added ACF.Weightable and ACF.Parentable globals

### DIFF
--- a/lua/autorun/acf_globals.lua
+++ b/lua/autorun/acf_globals.lua
@@ -4,8 +4,8 @@ ACF.MenuFunc = {}
 ACF.AmmoBlacklist = {}
 ACF.Version = 554 -- REMEMBER TO CHANGE THIS FOR GODS SAKE, OMFG!!!!!!! -wrex   Update the changelog too! -Ferv
 ACF.CurrentVersion = 0 -- just defining a variable, do not change
-ACF.Parentable = CreateConVar("acf_parentable", "1", {FCVAR_ARCHIVE})
-ACF.Weightable = CreateConVar("acf_weightable", "1", {FCVAR_ARCHIVE}) -- I don't know if the word "Weightable" exists but whatever
+ACF.Parentable = CreateConVar("acf_parentable", "0", {FCVAR_ARCHIVE})
+ACF.Weightable = CreateConVar("acf_weightable", "0", {FCVAR_ARCHIVE}) -- I don't know if the word "Weightable" exists but whatever
 
 ACF.Year = 1945
 

--- a/lua/autorun/acf_globals.lua
+++ b/lua/autorun/acf_globals.lua
@@ -4,6 +4,8 @@ ACF.MenuFunc = {}
 ACF.AmmoBlacklist = {}
 ACF.Version = 554 -- REMEMBER TO CHANGE THIS FOR GODS SAKE, OMFG!!!!!!! -wrex   Update the changelog too! -Ferv
 ACF.CurrentVersion = 0 -- just defining a variable, do not change
+ACF.Parentable = CreateConVar("acf_parentable", "1", {FCVAR_ARCHIVE})
+ACF.Weightable = CreateConVar("acf_weightable", "1", {FCVAR_ARCHIVE}) -- I don't know if the word "Weightable" exists but whatever
 
 ACF.Year = 1945
 
@@ -64,7 +66,7 @@ ACF.LiIonED = 0.458 -- li-ion energy density: kw hours / liter
 ACF.CuIToLiter = 0.0163871 -- cubic inches to liters
 
 ACF.RefillDistance = 300 --Distance in which ammo crate starts refilling.
-ACF.RefillSpeed = 700 -- (ACF.RefillSpeed / RoundMass) / Distance 
+ACF.RefillSpeed = 700 -- (ACF.RefillSpeed / RoundMass) / Distance
 
 ACF.DebrisScale = 20 -- Ignore debris that is less than this bounding radius.
 ACF.SpreadScale = 4		-- The maximum amount that damage can decrease a gun's accuracy.  Default 4x
@@ -114,7 +116,7 @@ if SERVER then
 	include("acf/server/sv_acfbase.lua")
 	include("acf/server/sv_acfdamage.lua")
 	include("acf/server/sv_acfballistics.lua")
-	
+
 	if ACF.EnableDefaultDP then
 		include("acf/server/sv_acfpermission.lua")
 	end
@@ -123,12 +125,12 @@ elseif CLIENT then
 
 	include("acf/client/cl_acfballistics.lua")
 	include("acf/client/cl_acfrender.lua")
-	
+
 	if ACF.EnableDefaultDP then
 		include("acf/client/cl_acfpermission.lua")
 		include("acf/client/gui/cl_acfsetpermission.lua")
 	end
-	
+
 	killicon.Add( "acf_AC", "HUD/killicons/acf_AC", Color( 200, 200, 48, 255 ) )
 	killicon.Add( "acf_AL", "HUD/killicons/acf_AL", Color( 200, 200, 48, 255 ) )
 	killicon.Add( "acf_C", "HUD/killicons/acf_C", Color( 200, 200, 48, 255 ) )
@@ -140,20 +142,20 @@ elseif CLIENT then
 	killicon.Add( "acf_RAC", "HUD/killicons/acf_RAC", Color( 200, 200, 48, 255 ) )
 	killicon.Add( "acf_SA", "HUD/killicons/acf_SA", Color( 200, 200, 48, 255 ) )
 	killicon.Add( "acf_ammo", "HUD/killicons/acf_ammo", Color( 200, 200, 48, 255 ) )
-	
+
 	CreateConVar("acf_cl_particlemul", 1)
-	
+
 	-- Cache results so we don't need to do expensive filesystem checks every time
 	local IsValidCache = {}
 
 	-- Returns whether or not a sound actually exists, fixes client timeout issues
 	function IsValidSound( path )
-		if IsValidCache[path] == nil then 
+		if IsValidCache[path] == nil then
 			IsValidCache[path] = file.Exists( string.format( "sound/%s", tostring( path ) ), "GAME" ) and true or false
 		end
 		return IsValidCache[path]
 	end
-	
+
 end
 
 include("acf/shared/rounds/roundap.lua")
@@ -171,7 +173,7 @@ include("acf/shared/acfcratelist.lua")
 --include("acf/shared/acfmissilelist.lua")
 
 ACF.Weapons = list.Get("ACFEnts")
-	
+
 ACF.Classes = list.Get("ACFClasses")
 
 ACF.RoundTypes = list.Get("ACFRoundTypes")
@@ -212,9 +214,9 @@ end)
 
 -- changes here will be automatically reflected in the armor properties tool
 function ACF_CalcArmor( Area, Ductility, Mass )
-	
+
 	return ( Mass * 1000 / Area / 0.78 ) / ( 1 + Ductility ) ^ 0.5 * ACF.ArmorMod
-	
+
 end
 
 function ACF_MuzzleVelocity( Propellant, Mass, Caliber )
@@ -227,19 +229,19 @@ function ACF_MuzzleVelocity( Propellant, Mass, Caliber )
 end
 
 function ACF_Kinetic( Speed , Mass, LimitVel )
-	
+
 	LimitVel = LimitVel or 99999
 	Speed = Speed/39.37
-	
+
 	local Energy = {}
 		Energy.Kinetic = ((Mass) * ((Speed)^2))/2000 --Energy in KiloJoules
 		Energy.Momentum = (Speed * Mass)
-		
+
 		local KE = (Mass * (Speed^ACF.KinFudgeFactor))/2000 + Energy.Momentum
 		Energy.Penetration = math.max( KE - (math.max(Speed-LimitVel,0)^2)/(LimitVel*5) * (KE/200)^0.95 , KE*0.1 )
 		--Energy.Penetration = math.max( KE - (math.max(Speed-LimitVel,0)^2)/(LimitVel*5) * (KE/200)^0.95 , KE*0.1 )
 		--Energy.Penetration = math.max(Energy.Momentum^ACF.KinFudgeFactor - math.max(Speed-LimitVel,0)/(LimitVel*5) * Energy.Momentum , Energy.Momentum*0.1)
-	
+
 	return Energy
 end
 
@@ -248,48 +250,48 @@ function ACF_CalcMassRatio( obj )
 	if not IsValid(obj) then return end
 	local Mass = 0
 	local PhysMass = 0
-	
+
 	-- find the physical parent highest up the chain
 	local Parent = obj
 	local depth = 0
-	
+
 	while Parent:GetParent():IsValid() and depth<6 do
 		Parent = Parent:GetParent()
 		depth = depth + 1
 	end
-	
+
 	-- get the shit that is physically attached to the vehicle
 	local PhysEnts = ACF_GetAllPhysicalConstraints( Parent )
-	
+
 	-- add any parented but not constrained props you sneaky bastards
 	local AllEnts = table.Copy( PhysEnts )
 	for k, v in pairs( AllEnts ) do
-		
+
 		table.Merge( AllEnts, ACF_GetAllChildren( v ) )
-	
+
 	end
-	
+
 	for k, v in pairs( AllEnts ) do
-		
+
 		if not IsValid( v ) then continue end
-		
+
 		local phys = v:GetPhysicsObject()
 		if not IsValid( phys ) then continue end
-		
+
 		Mass = Mass + phys:GetMass()
-		
+
 		if PhysEnts[ v ] then
 			PhysMass = PhysMass + phys:GetMass()
 		end
-		
+
 	end
-	
+
 	for k, v in pairs( AllEnts ) do
 		v.acfphystotal = PhysMass
 		v.acftotal = Mass
 		v.acflastupdatemass = CurTime()
 	end
-	
+
 end
 
 -- Cvars for recoil/he push
@@ -323,8 +325,8 @@ function ACF_CVarChangeCallback(CVar, Prev, New)
 	elseif( CVar == "acf_gunfire" ) then
 		ACF.GunfireEnabled = tobool( New )
 		local text = "disabled"
-		if ACF.GunfireEnabled then 
-			text = "enabled" 
+		if ACF.GunfireEnabled then
+			text = "enabled"
 		end
 		print ("ACF Gunfire has been " .. text)
 	end
@@ -341,7 +343,7 @@ else
 	local function ACF_Notify()
 		local Type = NOTIFY_ERROR
 		if tobool( net.ReadBit() ) then Type = NOTIFY_GENERIC end
-		
+
 		GAMEMODE:AddNotify( net.ReadString(), Type, 7 )
 	end
 	net.Receive( "ACF_Notify", ACF_Notify )
@@ -359,7 +361,7 @@ function ACF_UpdateChecking( )
 			if CLIENT then chat.AddText( Color( 255, 0, 0 ), "A newer version of ACF is available!" ) end
 		end
 		ACF.CurrentVersion = rev
-		
+
 	end, function() end)
 end
 ACF_UpdateChecking( )
@@ -396,18 +398,18 @@ if SERVER then
 	concommand.Add( "acf_smokewind", function(ply, cmd, args, str)
 			local validply = IsValid(ply)
 			local printmsg = validply and function(hud, msg) ply:PrintMessage(hud, msg) end or msgtoconsole
-			
+
 			if not args[1] then printmsg(HUD_PRINTCONSOLE,
 					"Set the wind intensity upon all smoke munitions." ..
 					"\n   This affects the ability of smoke to be used for screening effect." ..
 					"\n   Example; acf_smokewind 300")
 					return false
 			end
-			
+
 			if validply and not ply:IsAdmin() then
 					printmsg(HUD_PRINTCONSOLE, "You can't use this because you are not an admin.")
 					return false
-					
+
 			else
 					local wind = tonumber(args[1])
 
@@ -415,15 +417,15 @@ if SERVER then
 							printmsg(HUD_PRINTCONSOLE, "Command unsuccessful: that wind value could not be interpreted as a number!")
 							return false
 					end
-					
+
 					ACF.SmokeWind = wind
-					
+
 					net.Start("acf_smokewind")
 							net.WriteFloat(wind)
 					net.Broadcast()
-					
+
 					printmsg(HUD_PRINTCONSOLE, "Command SUCCESSFUL: set smoke-wind to " .. wind .. "!")
-					return true        
+					return true
 			end
 	end)
 
@@ -446,7 +448,7 @@ ONE HUGE HACK to get good killicons.
 -- disabling this for now because it was breaking killicons completely and i don't want to deal with it right now
 /*
 if SERVER then
-	
+
 	hook.Add("PlayerDeath", "ACF_PlayerDeath",function( victim, inflictor, attacker )
 		if inflictor:GetClass() == "acf_ammo" then
 			net.Start("ACF_KilledByACF")
@@ -463,15 +465,15 @@ end
 
 
 if CLIENT then
-	
+
 	net.Receive("ACF_KilledByACF", function()
 		local Table = string.Explode(";", net.ReadString())
 		local victim, gun, attacker = Table[1], Table[2], Table[3]
-		
+
 		if attacker == "worldspawn" then attacker = "" end
 		GAMEMODE:AddDeathNotice( attacker, -1, "acf_"..gun, victim, 1001 )
 	end)
-	
+
 	if not ACF.replacedPlayerKilled then
 		timer.Create("ACF_replacePlayerKilled", 1, 0, function()
 			local Hooks = usermessage.GetTable()

--- a/lua/entities/acf_engine.lua
+++ b/lua/entities/acf_engine.lua
@@ -9,27 +9,27 @@ ENT.WireDebugName = "ACF Engine"
 if CLIENT then
 
 	local ACF_EngineInfoWhileSeated = CreateClientConVar("ACF_EngineInfoWhileSeated", 0, true, false)
-	
+
 	-- copied from base_wire_entity: DoNormalDraw's notip arg isn't accessible from ENT:Draw defined there.
 	function ENT:Draw()
-	
+
 		local lply = LocalPlayer()
 		local hideBubble = not GetConVar("ACF_EngineInfoWhileSeated"):GetBool() and IsValid(lply) and lply:InVehicle()
-		
+
 		self.BaseClass.DoNormalDraw(self, false, hideBubble)
 		Wire_Render(self)
-		
-		if self.GetBeamLength and (not self.GetShowBeam or self:GetShowBeam()) then 
+
+		if self.GetBeamLength and (not self.GetShowBeam or self:GetShowBeam()) then
 			-- Every SENT that has GetBeamLength should draw a tracer. Some of them have the GetShowBeam boolean
-			Wire_DrawTracerBeam( self, 1, self.GetBeamHighlight and self:GetBeamHighlight() or false ) 
+			Wire_DrawTracerBeam( self, 1, self.GetBeamHighlight and self:GetBeamHighlight() or false )
 		end
-		
+
 	end
-	
+
 	function ACFEngineGUICreate( Table )
-		
+
 		acfmenupanel:CPanelText("Name", Table.name)
-		
+
 		acfmenupanel.CData.DisplayModel = vgui.Create( "DModelPanel", acfmenupanel.CustomDisplay )
 			acfmenupanel.CData.DisplayModel:SetModel( Table.model )
 			acfmenupanel.CData.DisplayModel:SetCamPos( Vector( 250, 500, 250 ) )
@@ -38,15 +38,15 @@ if CLIENT then
 			acfmenupanel.CData.DisplayModel:SetSize(acfmenupanel:GetWide(),acfmenupanel:GetWide())
 			acfmenupanel.CData.DisplayModel.LayoutEntity = function( panel, entity ) end
 		acfmenupanel.CustomDisplay:AddItem( acfmenupanel.CData.DisplayModel )
-			
+
 		acfmenupanel:CPanelText("Desc", Table.desc)
-		
+
 		local peakkw
 		local peakkwrpm
 		if (Table.iselec == true )then --elecs and turbs get peak power in middle of rpm range
 			peakkw = Table.torque * Table.limitrpm / (4*9548.8)
 			peakkwrpm = math.floor(Table.limitrpm / 2)
-		else	
+		else
 			peakkw = Table.torque * Table.peakmaxrpm / 9548.8
 			peakkwrpm = Table.peakmaxrpm
 		end
@@ -60,10 +60,10 @@ if CLIENT then
 
 		acfmenupanel:CPanelText("RPM", "Idle : "..(Table.idlerpm).." RPM\nIdeal RPM Range : "..(Table.peakminrpm).."-"..(Table.peakmaxrpm).." RPM\nRedline : "..(Table.limitrpm).." RPM")
 		acfmenupanel:CPanelText("Weight", "Weight : "..(Table.weight).." kg")
-		
-		
+
+
 		acfmenupanel:CPanelText("FuelType", "\nFuel Type : "..(Table.fuel))
-		
+
 		if Table.fuel == "Electric" then
 			local cons = ACF.ElecRate * peakkw / ACF.Efficiency[Table.enginetype]
 			acfmenupanel:CPanelText("FuelCons", "Peak energy use : "..math.Round(cons,1).." kW / "..math.Round(0.06*cons,1).." MJ/min")
@@ -76,20 +76,20 @@ if CLIENT then
 			local fuelcons = ACF.FuelRate * ACF.Efficiency[Table.enginetype] * ACF.TorqueBoost * peakkw / (60 * ACF.FuelDensity[Table.fuel])
 			acfmenupanel:CPanelText("FuelCons", (Table.fuel).." Use at "..peakkwrpm.." rpm : "..math.Round(fuelcons,2).." liters/min / "..math.Round(0.264*fuelcons,2).." gallons/min")
 		end
-		
+
 		if Table.requiresfuel then
 			acfmenupanel:CPanelText("Fuelreq", "REQUIRES FUEL")
 		else
 			acfmenupanel:CPanelText("FueledPower", "\nWhen supplied with fuel:\nPeak Power : "..math.floor(peakkw*ACF.TorqueBoost).." kW / "..math.Round(peakkw*ACF.TorqueBoost*1.34).." HP @ "..peakkwrpm.." RPM")
 			acfmenupanel:CPanelText("FueledTorque", "Peak Torque : "..(Table.torque*ACF.TorqueBoost).." n/m  / "..math.Round(Table.torque*ACF.TorqueBoost*0.73).." ft-lb")
 		end
-		
+
 		acfmenupanel.CustomDisplay:PerformLayout()
-		
+
 	end
-	
+
 	return
-	
+
 end
 
 function ENT:Initialize()
@@ -113,7 +113,7 @@ function ENT:Initialize()
 	Wire_TriggerOutput( self, "Entity", self )
 	self.WireDebugName = "ACF Engine"
 
-end  
+end
 
 function MakeACF_Engine(Owner, Pos, Angle, Id)
 
@@ -121,19 +121,19 @@ function MakeACF_Engine(Owner, Pos, Angle, Id)
 
 	local Engine = ents.Create( "acf_engine" )
 	if not IsValid( Engine ) then return false end
-	
+
 	local EID
 	local List = list.Get("ACFEnts")
 	if List.Mobility[Id] then EID = Id else EID = "5.7-V8" end
 	local Lookup = List.Mobility[EID]
-	
+
 	Engine:SetAngles(Angle)
 	Engine:SetPos(Pos)
 	Engine:Spawn()
 	Engine:SetPlayer(Owner)
 	Engine.Owner = Owner
 	Engine.Id = EID
-	
+
 	Engine.Model = Lookup.model
 	Engine.SoundPath = Lookup.sound
 	Engine.Weight = Lookup.weight
@@ -155,13 +155,13 @@ function MakeACF_Engine(Owner, Pos, Angle, Id)
 	Engine.SpecialHealth = true
 	Engine.SpecialDamage = true
 	Engine.TorqueMult = 1
-	
+
 	if Engine.EngineType == "GenericDiesel" then
 		Engine.TorqueScale = ACF.DieselTorqueScale
 	else
 		Engine.TorqueScale = ACF.TorqueScale
 	end
-	
+
 	--calculate boosted peak kw
 	if Engine.EngineType == "Turbine" or Engine.EngineType == "Electric" then
 		Engine.peakkw = Engine.PeakTorque * Engine.LimitRPM / (4 * 9548.8)
@@ -170,7 +170,7 @@ function MakeACF_Engine(Owner, Pos, Angle, Id)
 		Engine.peakkw = Engine.PeakTorque * Engine.PeakMaxRPM / 9548.8
 		Engine.PeakKwRPM = Engine.PeakMaxRPM
 	end
-	
+
 	--calculate base fuel usage
 	if Engine.EngineType == "Electric" then
 		Engine.FuelUse = ACF.ElecRate / (ACF.Efficiency[Engine.EngineType] * 60 * 60) --elecs use current power output, not max
@@ -179,27 +179,29 @@ function MakeACF_Engine(Owner, Pos, Angle, Id)
 	end
 
 	Engine.FlyRPM = 0
-	Engine:SetModel( Engine.Model )	
+	Engine:SetModel( Engine.Model )
 	Engine.Sound = nil
 	Engine.RPM = {}
 
-	Engine:PhysicsInit( SOLID_VPHYSICS )      	
-	Engine:SetMoveType( MOVETYPE_VPHYSICS )     	
+	Engine:PhysicsInit( SOLID_VPHYSICS )
+	Engine:SetMoveType( MOVETYPE_VPHYSICS )
 	Engine:SetSolid( SOLID_VPHYSICS )
 
 	Engine.Out = Engine:WorldToLocal(Engine:GetAttachment(Engine:LookupAttachment( "driveshaft" )).Pos)
 
-	local phys = Engine:GetPhysicsObject()  	
+	local phys = Engine:GetPhysicsObject()
 	if IsValid( phys ) then
-		phys:SetMass( Engine.Weight ) 
+		if ACF.Weightable:GetBool() == false then
+			phys:SetMass( Engine.Weight )
+		end
 	end
 
 	Engine:SetNWString( "WireName", Lookup.name )
 	Engine:UpdateOverlayText()
-	
+
 	Owner:AddCount("_acf_engine", Engine)
 	Owner:AddCleanup( "acfmenu", Engine )
-	
+
 	ACF_Activate( Engine, 0 )
 
 	return Engine
@@ -207,14 +209,14 @@ end
 list.Set( "ACFCvars", "acf_engine", {"id"} )
 duplicator.RegisterEntityClass("acf_engine", MakeACF_Engine, "Pos", "Angle", "Id")
 
-function ENT:Update( ArgsTable )	
-	-- That table is the player data, as sorted in the ACFCvars above, with player who shot, 
+function ENT:Update( ArgsTable )
+	-- That table is the player data, as sorted in the ACFCvars above, with player who shot,
 	-- and pos and angle of the tool trace inserted at the start
 
 	if self.Active then
 		return false, "Turn off the engine before updating it!"
 	end
-	
+
 	if ArgsTable[1] ~= self.Owner then -- Argtable[1] is the player that shot the tool
 		return false, "You don't own that engine!"
 	end
@@ -225,7 +227,7 @@ function ENT:Update( ArgsTable )
 	if Lookup.model ~= self.Model then
 		return false, "The new engine must have the same model!"
 	end
-	
+
 	local Feedback = ""
 	if Lookup.fuel != self.FuelType then
 		Feedback = " Fuel type changed, fuel tanks unlinked."
@@ -257,7 +259,7 @@ function ENT:Update( ArgsTable )
 	self.SpecialDamage = true
 	self.TorqueMult = self.TorqueMult or 1
 	self.FuelTank = 1
-	
+
 	if self.EngineType == "GenericDiesel" then
 		self.TorqueScale = ACF.DieselTorqueScale
 	elseif self.EngineType == "Electric" then
@@ -265,7 +267,7 @@ function ENT:Update( ArgsTable )
 	else
 		self.TorqueScale = ACF.TorqueScale
 	end
-	
+
 	--calculate boosted peak kw
 	if self.EngineType == "Turbine" or self.EngineType == "Electric" then
 		self.peakkw = self.PeakTorque * self.LimitRPM / (4 * 9548.8)
@@ -274,7 +276,7 @@ function ENT:Update( ArgsTable )
 		self.peakkw = self.PeakTorque * self.PeakMaxRPM / 9548.8
 		self.PeakKwRPM = self.PeakMaxRPM
 	end
-	
+
 	--calculate base fuel usage
 	if self.EngineType == "Electric" then
 		self.FuelUse = ACF.ElecRate / (ACF.Efficiency[self.EngineType] * 60 * 60) --elecs use current power output, not max
@@ -282,20 +284,22 @@ function ENT:Update( ArgsTable )
 		self.FuelUse = ACF.TorqueBoost * ACF.FuelRate * ACF.Efficiency[self.EngineType] * self.peakkw / (60 * 60)
 	end
 
-	self:SetModel( self.Model )	
+	self:SetModel( self.Model )
 	self:SetSolid( SOLID_VPHYSICS )
 	self.Out = self:WorldToLocal(self:GetAttachment(self:LookupAttachment( "driveshaft" )).Pos)
 
-	local phys = self:GetPhysicsObject()  	
-	if IsValid( phys ) then 
-		phys:SetMass( self.Weight ) 
+	local phys = self:GetPhysicsObject()
+	if IsValid( phys ) then
+		if ACF.Weightable:GetBool() == false then
+			phys:SetMass( self.Weight )
+		end
 	end
-	
+
 	self:SetNWString( "WireName", Lookup.name )
 	self:UpdateOverlayText()
-	
+
 	ACF_Activate( self, 1 )
-	
+
 	return true, "Engine updated successfully!"..Feedback
 end
 
@@ -305,9 +309,9 @@ function ENT:UpdateOverlayText()
 	text = text .. "Torque: " .. math.Round( self.PeakTorque * SpecialBoost ) .. " Nm / " .. math.Round( self.PeakTorque * SpecialBoost * 0.73 ) .. " ft-lb\n"
 	text = text .. "Powerband: " .. self.PeakMinRPM .. " - " .. self.PeakMaxRPM .. " RPM\n"
 	text = text .. "Redline: " .. self.LimitRPM .. " RPM"
-	
+
 	self:SetOverlayText( text )
-	
+
 end
 
 function ENT:TriggerInput( iname, value )
@@ -320,12 +324,12 @@ function ENT:TriggerInput( iname, value )
 			local HasFuel
 			if not self.RequiresFuel then
 				HasFuel = true
-			else 
+			else
 				for _,fueltank in pairs(self.FuelLink) do
 					if fueltank.Fuel > 0 and fueltank.Active then HasFuel = true break end
 				end
 			end
-			
+
 			if HasFuel then
 				self.Active = true
 				self.Sound = CreateSound(self, self.SoundPath)
@@ -352,8 +356,8 @@ end
 function ENT:ACF_Activate()
 	--Density of steel = 7.8g cm3 so 7.8kg for a 1mx1m plate 1m thick
 	local Entity = self
-	Entity.ACF = Entity.ACF or {} 
-	
+	Entity.ACF = Entity.ACF or {}
+
 	local Count
 	local PhysObj = Entity:GetPhysicsObject()
 	if PhysObj:GetMesh() then Count = #PhysObj:GetMesh() end
@@ -374,21 +378,21 @@ function ENT:ACF_Activate()
 		--	Entity.ACF.Volume = Size.x * Size.y * Size.z * 16.38
 		--end
 	end
-	
+
 	Entity.ACF.Ductility = Entity.ACF.Ductility or 0
 	--local Area = (Entity.ACF.Aera+Entity.ACF.Aera*math.Clamp(Entity.ACF.Ductility,-0.8,0.8))
 	local Area = (Entity.ACF.Aera)
 	--local Armour = (Entity:GetPhysicsObject():GetMass()*1000 / Area / 0.78) / (1 + math.Clamp(Entity.ACF.Ductility, -0.8, 0.8))^(1/2)	--So we get the equivalent thickness of that prop in mm if all it's weight was a steel plate
-	local Armour = (Entity:GetPhysicsObject():GetMass()*1000 / Area / 0.78) 
+	local Armour = (Entity:GetPhysicsObject():GetMass()*1000 / Area / 0.78)
 	--local Health = (Area/ACF.Threshold) * (1 + math.Clamp(Entity.ACF.Ductility, -0.8, 0.8))												--Setting the threshold of the prop aera gone
 	local Health = (Area/ACF.Threshold)
-	
-	local Percent = 1 
-	
+
+	local Percent = 1
+
 	if Recalc and Entity.ACF.Health and Entity.ACF.MaxHealth then
 		Percent = Entity.ACF.Health/Entity.ACF.MaxHealth
 	end
-	
+
 	if self.EngineType == "GenericDiesel" then
 		Entity.ACF.Health = Health * Percent * ACF.DieselEngineHPMult
 		Entity.ACF.MaxHealth = Health * ACF.DieselEngineHPMult
@@ -404,7 +408,7 @@ function ENT:ACF_Activate()
 	Entity.ACF.Type = nil
 	Entity.ACF.Mass = PhysObj:GetMass()
 	--Entity.ACF.Density = (PhysObj:GetMass()*1000)/Entity.ACF.Volume
-	
+
 	Entity.ACF.Type = "Prop"
 	--print(Entity.ACF.Health)
 end
@@ -413,7 +417,7 @@ function ENT:ACF_OnDamage( Entity, Energy, FrAera, Angle, Inflictor, Bone, Type 
 
 	local Mul = ((Type == "HEAT" and ACF.HEATMulEngine) or 1) --Heat penetrators deal bonus damage to engines
 	local HitRes = ACF_PropDamage( Entity, Energy, FrAera * Mul, Angle, Inflictor )	--Calling the standard damage prop function
-	
+
 	return HitRes --This function needs to return HitRes
 end
 
@@ -443,67 +447,70 @@ function ENT:Think()
 end
 
 function ENT:CheckLegal()
-	
+
 	-- make sure weight is not below stock
-	if self:GetPhysicsObject():GetMass() < self.Weight then return false end
-	
+	if self:GetPhysicsObject():GetMass() < self.Weight and ACF.Weightable:GetBool() == false then return false end
+
+	-- parenting restriction should apply to all entities
+	if ACF.Parentable:GetBool() then return true end
+
 	-- if it's not parented we're fine
 	if not IsValid( self:GetParent() ) then return true end
-	
+
 	-- but not if it's parented to a parented prop
 	if IsValid( self:GetParent():GetParent() ) then return false end
-	
+
 	-- parenting is only legal if it's also welded
 	for k, v in pairs( constraint.FindConstraints( self, "Weld" ) ) do
-		
+
 		if v.Ent1 == self:GetParent() or v.Ent2 == self:GetParent() then return true end
-		
+
 	end
-	
+
 	return false
-	
+
 end
 
 function ENT:CalcMassRatio()
-	
+
 	local Mass = 0
 	local PhysMass = 0
-	
+
 	-- get the shit that is physically attached to the vehicle
 	local PhysEnts = ACF_GetAllPhysicalConstraints( self )
-	
+
 	-- add any parented but not constrained props you sneaky bastards
 	local AllEnts = table.Copy( PhysEnts )
 	for k, v in pairs( PhysEnts ) do
-		
+
 		table.Merge( AllEnts, ACF_GetAllChildren( v ) )
-	
+
 	end
-	
+
 	for k, v in pairs( AllEnts ) do
-		
+
 		if not IsValid( v ) then continue end
-		
+
 		local phys = v:GetPhysicsObject()
 		if not IsValid( phys ) then continue end
-		
+
 		Mass = Mass + phys:GetMass()
-		
+
 		if PhysEnts[ v ] then
 			PhysMass = PhysMass + phys:GetMass()
 		end
-		
+
 	end
 
 	self.MassRatio = PhysMass / Mass
-	
+
 	Wire_TriggerOutput( self, "Mass", math.Round( Mass, 2 ) )
 	Wire_TriggerOutput( self, "Physical Mass", math.Round( PhysMass, 2 ) )
-	
+
 end
 
 function ENT:ACFInit()
-	
+
 	self:CalcMassRatio()
 
 	self.LastThink = CurTime()
@@ -517,13 +524,13 @@ function ENT:CalcRPM()
 	local DeltaTime = CurTime() - self.LastThink
 	-- local AutoClutch = math.min(math.max(self.FlyRPM-self.IdleRPM,0)/(self.IdleRPM+self.LimitRPM/10),1)
 	--local ClutchRatio = math.min(Clutch/math.max(TorqueDiff,0.05),1)
-	
+
 	--find next active tank with fuel
 	local Tank = nil
 	local boost = 1
 	local i = 0
 	local MaxTanks = #self.FuelLink
-	
+
 	while i <= MaxTanks  and not (Tank and Tank:IsValid() and Tank.Fuel > 0) do
 		self.FuelTank = self.FuelTank % MaxTanks + 1
 		Tank = self.FuelLink[self.FuelTank]
@@ -533,7 +540,7 @@ function ENT:CalcRPM()
 		Tank = nil
 		i = i + 1
 	end
-	
+
 	--calculate fuel usage
 	if Tank then
 		local Consumption
@@ -552,52 +559,52 @@ function ENT:CalcRPM()
 	else
 		Wire_TriggerOutput(self, "Fuel Use", 0)
 	end
-	
+
 	--adjusting performance based on damage
 	self.TorqueMult = math.Clamp(((1 - self.TorqueScale) / (0.5)) * ((self.ACF.Health/self.ACF.MaxHealth) - 1) + 1, self.TorqueScale, 1)
 	self.PeakTorque = self.PeakTorqueHeld * self.TorqueMult
 
 	-- Calculate the current torque from flywheel RPM
 	self.Torque = boost * self.Throttle * math.max( self.PeakTorque * math.min( self.FlyRPM / self.PeakMinRPM, (self.LimitRPM - self.FlyRPM) / (self.LimitRPM - self.PeakMaxRPM), 1 ), 0 )
-	
-	local Drag 
+
+	local Drag
 	if self.iselec == true then
 		 Drag = self.PeakTorque * (math.max( self.FlyRPM - self.IdleRPM, 0) / self.FlywheelOverride) * (1 - self.Throttle) / self.Inertia
 	else
 		 Drag = self.PeakTorque * (math.max( self.FlyRPM - self.IdleRPM, 0) / self.PeakMaxRPM) * ( 1 - self.Throttle) / self.Inertia
 	end
-	
+
 	-- Let's accelerate the flywheel based on that torque
 	self.FlyRPM = math.max( self.FlyRPM + self.Torque / self.Inertia - Drag, 1 )
-	
+
 	-- The gearboxes don't think on their own, it's the engine that calls them, to ensure consistent execution order
 	local Boxes = table.Count( self.GearLink )
-	
+
 	local TotalReqTq = 0
-	
+
 	-- Get the requirements for torque for the gearboxes (Max clutch rating minus any wheels currently spinning faster than the Flywheel)
 	for Key, Link in pairs( self.GearLink ) do
-	
+
 		if not Link.Ent.Legal then continue end
-		
+
 		Link.ReqTq = Link.Ent:Calc( self.FlyRPM, self.Inertia )
 		TotalReqTq = TotalReqTq + Link.ReqTq
-		
+
 	end
 
 	-- This is the presently available torque from the engine
 	local TorqueDiff = math.max( self.FlyRPM - self.IdleRPM, 0 ) * self.Inertia
-	
+
 	-- Calculate the ratio of total requested torque versus what's avaliable
 	local AvailRatio = math.min( TorqueDiff / TotalReqTq / Boxes, 1 )
-	
+
 	-- Split the torque fairly between the gearboxes who need it
 	for Key, Link in pairs( self.GearLink ) do
-		
+
 		if not Link.Ent.Legal then continue end
-		
+
 		Link.Ent:Act( Link.ReqTq * AvailRatio * self.MassRatio, DeltaTime, self.MassRatio )
-		
+
 	end
 
 	self.FlyRPM = self.FlyRPM - math.min( TorqueDiff, TotalReqTq ) / self.Inertia
@@ -615,45 +622,45 @@ function ENT:CalcRPM()
 	Wire_TriggerOutput(self, "Torque", math.floor(self.Torque))
 	Wire_TriggerOutput(self, "Power", math.floor(Power))
 	Wire_TriggerOutput(self, "RPM", self.FlyRPM)
-	
+
 	if self.Sound then
 		self.Sound:ChangePitch( math.min( 20 + (SmoothRPM * self.SoundPitch) / 50, 255 ), 0 )
 		self.Sound:ChangeVolume( 0.25 + (0.1 + 0.9 * ((SmoothRPM / self.LimitRPM) ^ 1.5)) * self.Throttle / 1.5, 0 )
 	end
-	
+
 	return RPM
 end
 
 function ENT:CheckRopes()
-	
+
 	for Key, Link in pairs( self.GearLink ) do
-		
+
 		local Ent = Link.Ent
-		
+
 		-- make sure the rope is still there
-		if not IsValid( Link.Rope ) then 
+		if not IsValid( Link.Rope ) then
 			self:Unlink( Ent )
 		continue end
-		
+
 		local OutPos = self:LocalToWorld( self.Out )
 		local InPos = Ent:LocalToWorld( Ent.In )
-		
+
 		-- make sure it is not stretched too far
 		if OutPos:Distance( InPos ) > Link.RopeLen * 1.5 then
 			self:Unlink( Ent )
 		continue end
-		
+
 		-- make sure the angle is not excessive
 		local Direction
 		if self.IsTrans then Direction = -self:GetRight() else Direction = self:GetForward() end
-		
+
 		local DrvAngle = ( OutPos - InPos ):GetNormalized():DotProduct( Direction )
 		if DrvAngle < 0.7 then
 			self:Unlink( Ent )
 		end
-		
+
 	end
-	
+
 end
 
 --unlink fuel tanks out of range
@@ -672,42 +679,42 @@ function ENT:Link( Target )
 	if not IsValid( Target ) or (Target:GetClass() ~= "acf_gearbox" and Target:GetClass() ~= "acf_fueltank") then
 		return false, "Can only link to gearboxes or fuel tanks!"
 	end
-	
-	if Target:GetClass() == "acf_fueltank" then 
+
+	if Target:GetClass() == "acf_fueltank" then
 		return self:LinkFuel( Target )
 	end
-	
+
 	-- Check if target is already linked
 	for Key, Link in pairs( self.GearLink ) do
 		if Link.Ent == Target then
 			return false, "That is already linked to this engine!"
 		end
 	end
-	
+
 	-- make sure the angle is not excessive
 	local InPos = Target:LocalToWorld( Target.In )
 	local OutPos = self:LocalToWorld( self.Out )
-	
+
 	local Direction
 	if self.IsTrans then Direction = -self:GetRight() else Direction = self:GetForward() end
-	
+
 	local DrvAngle = ( OutPos - InPos ):GetNormalized():DotProduct( Direction )
 	if DrvAngle < 0.7 then
 		return false, "Cannot link due to excessive driveshaft angle!"
 	end
-	
+
 	local Rope = constraint.CreateKeyframeRope( OutPos, 1, "cable/cable2", nil, self, self.Out, 0, Target, Target.In, 0 )
-	
+
 	local Link = {
 		Ent = Target,
 		Rope = Rope,
 		RopeLen = ( OutPos - InPos ):Length(),
 		ReqTq = 0
 	}
-	
+
 	table.insert( self.GearLink, Link )
 	table.insert( Target.Master, self )
-	
+
 	return true, "Link successful!"
 end
 
@@ -716,74 +723,74 @@ function ENT:Unlink( Target )
 	if Target:GetClass() == "acf_fueltank" then
 		return self:UnlinkFuel( Target )
 	end
-	
+
 	for Key, Link in pairs( self.GearLink ) do
-		
+
 		if Link.Ent == Target then
-			
+
 			-- Remove any old physical ropes leftover from dupes
 			for Key, Rope in pairs( constraint.FindConstraints( Link.Ent, "Rope" ) ) do
 				if Rope.Ent1 == self or Rope.Ent2 == self then
 					Rope.Constraint:Remove()
 				end
 			end
-			
+
 			if IsValid( Link.Rope ) then
 				Link.Rope:Remove()
 			end
-			
+
 			table.remove( self.GearLink,Key )
-			
+
 			return true, "Unlink successful!"
-			
+
 		end
-		
+
 	end
-	
+
 	return false, "That gearbox is not linked to this engine!"
-	
+
 end
 
 function ENT:LinkFuel( Target )
-	
+
 	if not (self.FuelType == "Multifuel" and not (Target.FuelType == "Electric")) then
 		if self.FuelType ~= Target.FuelType then
 			return false, "Cannot link because fuel type is incompatible."
 		end
 	end
-	
+
 	if Target.NoLinks then
 		return false, "This fuel tank doesn\'t allow linking."
 	end
-	
+
 	for Key,Value in pairs(self.FuelLink) do
-		if Value == Target then 
+		if Value == Target then
 			return false, "That fuel tank is already linked to this engine!"
 		end
 	end
-	
+
 	if self:GetPos():Distance( Target:GetPos() ) > 512 then
 		return false, "Fuel tank is too far away."
 	end
-	
+
 	table.insert( self.FuelLink, Target )
 	table.insert( Target.Master, self )
-	
+
 	return true, "Link successful!"
-	
+
 end
 
 function ENT:UnlinkFuel( Target )
-	
+
 	for Key, Value in pairs( self.FuelLink ) do
 		if Value == Target then
 			table.remove( self.FuelLink, Key )
 			return true, "Unlink successful!"
 		end
 	end
-	
+
 	return false, "That fuel tank is not linked to this engine!"
-	
+
 end
 
 function ENT:PreEntityCopy()
@@ -804,7 +811,7 @@ function ENT:PreEntityCopy()
 	if info.entities then
 		duplicator.StoreEntityModifier( self, "GearLink", info )
 	end
-	
+
 	--fuel tank link saving
 	local fuel_info = {}
 	local fuel_entids = {}
@@ -816,7 +823,7 @@ function ENT:PreEntityCopy()
 	for Key, Value in pairs(self.FuelLink) do					--Then save it
 		table.insert(fuel_entids, Value:EntIndex())
 	end
-	
+
 	fuel_info.entities = fuel_entids
 	if fuel_info.entities then
 		duplicator.StoreEntityModifier( self, "FuelLink", fuel_info )
@@ -858,7 +865,7 @@ function ENT:PostEntityPaste( Player, Ent, CreatedEntities )
 		end
 		Ent.EntityMods.FuelLink = nil
 	end
-	
+
 	//Wire dupe info
 	self.BaseClass.PostEntityPaste( self, Player, Ent, CreatedEntities )
 

--- a/lua/entities/acf_fueltank.lua
+++ b/lua/entities/acf_fueltank.lua
@@ -11,23 +11,23 @@ ENT.WireDebugName = "ACF Fuel Tank"
 if CLIENT then
 
 	local ACF_FuelInfoWhileSeated = CreateClientConVar("ACF_FuelInfoWhileSeated", 0, true, false)
-	
+
 	-- copied from base_wire_entity: DoNormalDraw's notip arg isn't accessible from ENT:Draw defined there.
 	function ENT:Draw()
-	
+
 		local lply = LocalPlayer()
 		local hideBubble = not GetConVar("ACF_FuelInfoWhileSeated"):GetBool() and IsValid(lply) and lply:InVehicle()
-		
+
 		self.BaseClass.DoNormalDraw(self, false, hideBubble)
 		Wire_Render(self)
-		
-		if self.GetBeamLength and (not self.GetShowBeam or self:GetShowBeam()) then 
+
+		if self.GetBeamLength and (not self.GetShowBeam or self:GetShowBeam()) then
 			-- Every SENT that has GetBeamLength should draw a tracer. Some of them have the GetShowBeam boolean
-			Wire_DrawTracerBeam( self, 1, self.GetBeamHighlight and self:GetBeamHighlight() or false ) 
+			Wire_DrawTracerBeam( self, 1, self.GetBeamHighlight and self:GetBeamHighlight() or false )
 		end
-		
+
 	end
-	
+
 	function ACFFuelTankGUICreate( Table )
 		if not acfmenupanel.CustomDisplay then return end
 		if not acfmenupanel.FuelTankData then
@@ -35,15 +35,15 @@ if CLIENT then
 			acfmenupanel.FuelTankData.Id = "Tank_4x4x2"
 			acfmenupanel.FuelTankData.FuelID = "Petrol"
 		end
-		
+
 		local Tanks = list.Get("ACFEnts").FuelTanks
 		local SortedTanks = {}
 		for n in pairs(Tanks) do table.insert(SortedTanks,n) end
 		table.sort(SortedTanks)
-		
+
 		acfmenupanel:CPanelText("Name", Table.name)
 		acfmenupanel:CPanelText("Desc", Table.desc)
-		
+
 		-- tank size dropbox
 		acfmenupanel.CData.TankSizeSelect = vgui.Create( "DComboBox", acfmenupanel.CustomDisplay )
 			acfmenupanel.CData.TankSizeSelect:SetSize(100, 30)
@@ -56,7 +56,7 @@ if CLIENT then
 			acfmenupanel.CData.TankSizeSelect:SetText(acfmenupanel.FuelTankData.Id)
 			RunConsoleCommand( "acfmenu_data1", acfmenupanel.FuelTankData.Id )
 		acfmenupanel.CustomDisplay:AddItem( acfmenupanel.CData.TankSizeSelect )
-		
+
 		-- fuel type dropbox
 		acfmenupanel.CData.FuelSelect = vgui.Create( "DComboBox", acfmenupanel.CustomDisplay )
 			acfmenupanel.CData.FuelSelect:SetSize(100, 30)
@@ -71,30 +71,30 @@ if CLIENT then
 			acfmenupanel.CData.FuelSelect:SetText(acfmenupanel.FuelTankData.FuelID)
 			RunConsoleCommand( "acfmenu_data2", acfmenupanel.FuelTankData.FuelID )
 		acfmenupanel.CustomDisplay:AddItem( acfmenupanel.CData.FuelSelect )
-		
+
 		ACFFuelTankGUIUpdate( Table )
-		
+
 		acfmenupanel.CustomDisplay:PerformLayout()
-		
+
 	end
 
 	function ACFFuelTankGUIUpdate( Table )
 
 		if not acfmenupanel.CustomDisplay then return end
-		
+
 		local Tanks = list.Get("ACFEnts").FuelTanks
-		
+
 		local TankID = acfmenupanel.FuelTankData.Id
 		local FuelID = acfmenupanel.FuelTankData.FuelID
 		local Dims = Tanks[TankID].dims
-		
+
 		local Wall = 0.1 --wall thickness in inches
 		local Size = math.floor(Dims[1] * Dims[2] * Dims[3])
 		local Volume = math.floor((Dims[1] - Wall) * (Dims[2] - Wall) * (Dims[3] - Wall))
 		local Capacity = Volume * ACF.CuIToLiter * ACF.TankVolumeMul * 0.125
 		local EmptyMass = ((Size - Volume)*16.387)*7.9/1000
 		local Mass = EmptyMass + Capacity * ACF.FuelDensity[FuelID]
-			
+
 		--fuel and tank info
 		if FuelID == "Electric" then
 			local kwh = Capacity * ACF.LiIonED
@@ -102,7 +102,7 @@ if CLIENT then
 			acfmenupanel:CPanelText("TankDesc", Tanks[TankID].desc .. "\n")
 			acfmenupanel:CPanelText("Cap", "Charge: " ..math.Round(kwh,1).. " kW hours / " ..math.Round(kwh*3.6,1).. " MJ")
 			acfmenupanel:CPanelText("Mass", "Mass: " ..math.Round(Mass,1).. " kg")
-		else 
+		else
 			acfmenupanel:CPanelText("TankName", Tanks[TankID].name .. " fuel tank")
 			acfmenupanel:CPanelText("TankDesc", Tanks[TankID].desc .. "\n")
 			acfmenupanel:CPanelText("Cap", "Capacity: " ..math.Round(Capacity,1).. " liters / " ..math.Round(Capacity*0.264172,1).. " gallons")
@@ -114,7 +114,7 @@ if CLIENT then
 			text = "\nThis fuel tank won\'t link to engines. It's intended to resupply fuel to other fuel tanks."
 		end
 		acfmenupanel:CPanelText("Links", text)
-		
+
 		--fuel tank model display
 		if not acfmenupanel.CData.DisplayModel then
 			acfmenupanel.CData.DisplayModel = vgui.Create( "DModelPanel", acfmenupanel.CustomDisplay )
@@ -127,21 +127,21 @@ if CLIENT then
 			acfmenupanel.CustomDisplay:AddItem( acfmenupanel.CData.DisplayModel )
 		end
 		acfmenupanel.CData.DisplayModel:SetModel( Tanks[TankID].model )
-		
+
 	end
-	
+
 	return
-	
+
 end
 
 function ENT:Initialize()
-	
+
 	self.CanUpdate = true
 	self.SpecialHealth = true	--If true, use the ACF_Activate function defined by this ent
 	self.SpecialDamage = true	--If true, use the ACF_OnDamage function defined by this ent
-	self.IsExplosive = true		
+	self.IsExplosive = true
 	self.Exploding = false
-	
+
 	self.Size = 0 --outer dimensions
 	self.Volume = 0 --total internal volume in cubic inches
 	self.Capacity = 0  --max fuel capacity in liters
@@ -152,27 +152,27 @@ function ENT:Initialize()
 	self.Active = false
 	self.SupplyFuel = false
 	self.Leaking = 0
-	
+
 	self.Inputs = Wire_CreateInputs( self, { "Active", "Refuel Duty" } )
 	self.Outputs = WireLib.CreateSpecialOutputs( self,
-		{ "Fuel", "Capacity", "Leaking", "Entity" }, 
+		{ "Fuel", "Capacity", "Leaking", "Entity" },
 		{ "NORMAL", "NORMAL", "NORMAL", "ENTITY" }
 	)
 	Wire_TriggerOutput( self, "Leaking", 0 )
 	Wire_TriggerOutput( self, "Entity", self )
-	
+
 	self.Master = {} --engines linked to this tank
 	ACF.FuelTanks = ACF.FuelTanks or {} --master list of acf fuel tanks
-	
+
 	self.LastThink = 0
 	self.NextThink = CurTime() +  1
-	
+
 end
 
 function ENT:ACF_Activate( Recalc )
-	
-	self.ACF = self.ACF or {} 
-	
+
+	self.ACF = self.ACF or {}
+
 	local PhysObj = self:GetPhysicsObject()
 	if not self.ACF.Aera then
 		self.ACF.Aera = PhysObj:GetSurfaceArea() * 6.45
@@ -180,15 +180,15 @@ function ENT:ACF_Activate( Recalc )
 	if not self.ACF.Volume then
 		self.ACF.Volume = PhysObj:GetVolume() * 1
 	end
-	
+
 	local Armour = self.EmptyMass*1000 / self.ACF.Aera / 0.78 --So we get the equivalent thickness of that prop in mm if all it's weight was a steel plate
-	local Health = self.ACF.Volume/ACF.Threshold							--Setting the threshold of the prop aera gone 
-	
-	local Percent = 1 
+	local Health = self.ACF.Volume/ACF.Threshold							--Setting the threshold of the prop aera gone
+
+	local Percent = 1
 	if Recalc and self.ACF.Health and self.ACF.MaxHealth then
 		Percent = self.ACF.Health/self.ACF.MaxHealth
 	end
-	
+
 	self.ACF.Health = Health * Percent
 	self.ACF.MaxHealth = Health
 	self.ACF.Armour = Armour * (0.5 + Percent/2)
@@ -197,17 +197,17 @@ function ENT:ACF_Activate( Recalc )
 	self.ACF.Mass = self.Mass
 	self.ACF.Density = (PhysObj:GetMass()*1000) / self.ACF.Volume
 	self.ACF.Type = "Prop"
-	
+
 end
 
 function ENT:ACF_OnDamage( Entity, Energy, FrAera, Angle, Inflictor, Bone, Type )	--This function needs to return HitRes
 
 	local Mul = ((Type == "HEAT" and ACF.HEATMulFuel) or 1) --Heat penetrators deal bonus damage to fuel
 	local HitRes = ACF_PropDamage( Entity, Energy, FrAera * Mul, Angle, Inflictor )	--Calling the standard damage prop function
-	
+
 	local NoExplode = self.FuelType == "Diesel" and not (Type == "HE" or Type == "HEAT")
 	if self.Exploding or NoExplode or not self.IsExplosive then return HitRes end
-	
+
 	if HitRes.Kill then
 		if hook.Run( "ACF_FuelExplode", self ) == false then return HitRes end
 		self.Exploding = true
@@ -217,10 +217,10 @@ function ENT:ACF_OnDamage( Entity, Energy, FrAera, Angle, Inflictor, Bone, Type 
 		ACF_ScaledExplosion( self )
 		return HitRes
 	end
-	
+
 	local Ratio = (HitRes.Damage/self.ACF.Health)^0.75 --chance to explode from sheer damage, small shots = small chance
 	local ExplodeChance = (1-(self.Fuel/self.Capacity))^0.75 --chance to explode from fumes in tank, less fuel = more explodey
-	 
+
 	if math.Rand(0,1) < (ExplodeChance + Ratio) then  --it's gonna blow
 		if hook.Run( "ACF_FuelExplode", self ) == false then return HitRes end
 		self.Inflictor = Inflictor
@@ -230,19 +230,19 @@ function ENT:ACF_OnDamage( Entity, Energy, FrAera, Angle, Inflictor, Bone, Type 
 		self:NextThink( CurTime() + 0.1 )
 		self.Leaking = self.Leaking + self.Fuel * ((HitRes.Damage/self.ACF.Health)^1.5) * 0.25
 	end
-	
+
 	return HitRes
-	
+
 end
 
 function MakeACF_FuelTank(Owner, Pos, Angle, Id, Data1, Data2, Data3, Data4, Data5, Data6, Data7, Data8, Data9, Data10)
 
 	if IsValid(Owner) and not Owner:CheckLimit("_acf_misc") then return false end
-	
+
 	local SId = Data1
 	local Tanks = list.Get("ACFEnts").FuelTanks
 	if not Tanks[SId].model then return false end --SId = "Tank_4x4x2" end
-	
+
 	local Tank = ents.Create("acf_fueltank")
 	if not IsValid(Tank) then return false end
 	Tank:SetAngles(Angle)
@@ -250,27 +250,27 @@ function MakeACF_FuelTank(Owner, Pos, Angle, Id, Data1, Data2, Data3, Data4, Dat
 	Tank:Spawn()
 	Tank:SetPlayer(Owner)
 	Tank.Owner = Owner
-	
+
 	Tank.Id = Id
 	Tank.SizeId = SId
 	Tank.Model = Tanks[Tank.SizeId].model
-	Tank:SetModel( Tank.Model )	
-	
-	Tank:PhysicsInit( SOLID_VPHYSICS )      	
-	Tank:SetMoveType( MOVETYPE_VPHYSICS )     	
+	Tank:SetModel( Tank.Model )
+
+	Tank:PhysicsInit( SOLID_VPHYSICS )
+	Tank:SetMoveType( MOVETYPE_VPHYSICS )
 	Tank:SetSolid( SOLID_VPHYSICS )
 
 	Tank:UpdateFuelTank(Id, SId, Data2)
-	
+
 	if IsValid(Owner) then
 		Owner:AddCount( "_acf_fueltank", Tank )
 		Owner:AddCleanup( "acfmenu", Tank )
 	end
-	
+
 	table.insert(ACF.FuelTanks, Tank)
-	
+
 	return Tank
-	
+
 end
 list.Set( "ACFCvars", "acf_fueltank", {"id", "data1", "data2"} )
 duplicator.RegisterEntityClass("acf_fueltank", MakeACF_FuelTank, "Pos", "Angle", "Id", "SizeId", "FuelType" )
@@ -282,7 +282,7 @@ function ENT:UpdateFuelTank(Id, Data1, Data2)
 	local Wall = 0.1 --wall thickness in inches
 	local pct = 1 --how full is the tank?
 	local new = self.Capacity == 0 -- is it new or updated?
-	if not new then pct = self.Fuel / self.Capacity end 
+	if not new then pct = self.Fuel / self.Capacity end
 	self.Size = math.floor(Size.x * Size.y * Size.z) -- total volume of tank (cu in)
 	self.Volume = math.floor((Size.x - Wall) * (Size.y - Wall) * (Size.z - Wall)) -- internal volume in cubic inches
 	self.Capacity = self.Volume * ACF.CuIToLiter * ACF.TankVolumeMul * 0.125 --internal volume available for fuel in liters
@@ -290,7 +290,7 @@ function ENT:UpdateFuelTank(Id, Data1, Data2)
 	self.FuelType = Data2
 	self.IsExplosive = self.FuelType ~= "Electric" and lookup[Data1].explosive ~= false
 	self.NoLinks = lookup[Data1].nolinks == true
-	
+
 	if self.FuelType == "Electric" then
 		self.Liters = self.Capacity --batteries capacity is different from internal volume
 		self.Capacity = self.Capacity * ACF.LiIonED
@@ -298,26 +298,26 @@ function ENT:UpdateFuelTank(Id, Data1, Data2)
 	else
 		self.Fuel = pct * self.Capacity
 	end
-	
+
 	self:UpdateFuelMass()
-	
+
 	Wire_TriggerOutput( self, "Capacity", math.Round(self.Capacity,2) )
 	self:UpdateOverlayText()
-	
+
 end
 
 function ENT:UpdateOverlayText()
-	
+
 	local text = "Fuel Type: " .. self.FuelType
-	
+
 	if self.FuelType == "Electric" then
 		text = text .. "\nCharge Level: " .. math.Round( self.Fuel, 1 ) .. " kWh / " .. math.Round( self.Fuel * 3.6, 1 ) .. " MJ"
 	else
 		text = text .. "\nFuel Remaining: " .. math.Round( self.Fuel, 1 ) .. " liters / " .. math.Round( self.Fuel * 0.264172, 1 ) .. " gallons"
 	end
-	
+
 	self:SetOverlayText( text )
-	
+
 end
 
 function ENT:UpdateFuelMass()
@@ -328,24 +328,26 @@ function ENT:UpdateFuelMass()
 		local FuelMass = self.Fuel * ACF.FuelDensity[self.FuelType]
 		self.Mass = self.EmptyMass + FuelMass
 	end
-	
-	local phys = self:GetPhysicsObject()  	
-	if (phys:IsValid()) then 
-		phys:SetMass( self.Mass ) 
+
+	local phys = self:GetPhysicsObject()
+	if (phys:IsValid()) then
+		if ACF.Weightable:GetBool() == false then
+			phys:SetMass( self.Mass )
+		end
 	end
-	
+
 	self:UpdateOverlayText()
-	
+
 end
 
 function ENT:Update( ArgsTable )
 
 	local Feedback = ""
-	
+
 	if ( ArgsTable[1] != self.Owner ) then --Argtable[1] is the player that shot the tool
 		return false, "You don't own that fuel tank!"
 	end
-	
+
 	if ( ArgsTable[6] != self.FuelType ) then
 		for Key, Engine in pairs( self.Master ) do
 			if Engine:IsValid() then
@@ -354,7 +356,7 @@ function ENT:Update( ArgsTable )
 		end
 		Feedback = " New fuel type loaded, fuel tank unlinked."
 	end
-	
+
 	self:UpdateFuelTank(ArgsTable[4], ArgsTable[5], ArgsTable[6]) --Id, SizeId, FuelType
 
 	return true, "Fuel tank successfully updated."..Feedback
@@ -379,16 +381,16 @@ function ENT:TriggerInput( iname, value )
 end
 
 function ENT:Think()
-	
+
 	self:NextThink( CurTime() +  1 )
-	
+
 	if self.Leaking > 0 then
 		self:NextThink( CurTime() + 0.25 )
 		self.Fuel = math.max(self.Fuel - self.Leaking,0)
 		self.Leaking = math.Clamp(self.Leaking - (1 / math.max(self.Fuel,1))^0.5, 0, self.Fuel) --fuel tanks are self healing
 		Wire_TriggerOutput(self, "Leaking", (self.Leaking > 0) and 1 or 0)
 	end
-	
+
 	--refuelling
 	if self.Active and self.SupplyFuel and self.Fuel > 0 then
 		for _,Tank in pairs(ACF.FuelTanks) do
@@ -410,13 +412,13 @@ function ENT:Think()
 			end
 		end
 	end
-	
+
 	self:UpdateFuelMass()
-	
+
 	Wire_TriggerOutput(self, "Fuel", self.Fuel)
-	
+
 	self.LastThink = CurTime()
-	
+
 	return true
 
 end
@@ -428,7 +430,7 @@ function ENT:OnRemove()
 			self.Master[Key]:Unlink( self )
 		end
 	end
-	
+
 	if #ACF.FuelTanks > 0 then
 		for k,v in pairs(ACF.FuelTanks) do
 			if v == self then
@@ -436,5 +438,5 @@ function ENT:OnRemove()
 			end
 		end
 	end
-	
+
 end

--- a/lua/entities/acf_gearbox.lua
+++ b/lua/entities/acf_gearbox.lua
@@ -8,25 +8,25 @@ ENT.WireDebugName = "ACF Gearbox"
 if CLIENT then
 
 	local ACF_GearboxInfoWhileSeated = CreateClientConVar("ACF_GearboxInfoWhileSeated", 0, true, false)
-	
+
 	-- copied from base_wire_entity: DoNormalDraw's notip arg isn't accessible from ENT:Draw defined there.
 	function ENT:Draw()
-	
+
 		local lply = LocalPlayer()
 		local hideBubble = not GetConVar("ACF_GearboxInfoWhileSeated"):GetBool() and IsValid(lply) and lply:InVehicle()
-		
+
 		self.BaseClass.DoNormalDraw(self, false, hideBubble)
 		Wire_Render(self)
-		
-		if self.GetBeamLength and (not self.GetShowBeam or self:GetShowBeam()) then 
+
+		if self.GetBeamLength and (not self.GetShowBeam or self:GetShowBeam()) then
 			-- Every SENT that has GetBeamLength should draw a tracer. Some of them have the GetShowBeam boolean
-			Wire_DrawTracerBeam( self, 1, self.GetBeamHighlight and self:GetBeamHighlight() or false ) 
+			Wire_DrawTracerBeam( self, 1, self.GetBeamHighlight and self:GetBeamHighlight() or false )
 		end
-		
+
 	end
-	
+
 	function ACFGearboxGUICreate( Table )
-		
+
 		if not acfmenupanel.GearboxData then
 			acfmenupanel.GearboxData = {}
 		end
@@ -34,9 +34,9 @@ if CLIENT then
 			acfmenupanel.GearboxData[Table.id] = {}
 			acfmenupanel.GearboxData[Table.id].GearTable = Table.geartable
 		end
-			
+
 		acfmenupanel:CPanelText("Name", Table.name)
-		
+
 		acfmenupanel.CData.DisplayModel = vgui.Create( "DModelPanel", acfmenupanel.CustomDisplay )
 			acfmenupanel.CData.DisplayModel:SetModel( Table.model )
 			acfmenupanel.CData.DisplayModel:SetCamPos( Vector( 250, 500, 250 ) )
@@ -45,9 +45,9 @@ if CLIENT then
 			acfmenupanel.CData.DisplayModel:SetSize(acfmenupanel:GetWide(),acfmenupanel:GetWide())
 			acfmenupanel.CData.DisplayModel.LayoutEntity = function( panel, entity ) end
 		acfmenupanel.CustomDisplay:AddItem( acfmenupanel.CData.DisplayModel )
-		
+
 		acfmenupanel:CPanelText("Desc", Table.desc)	--Description (Name, Desc)
-		
+
 		if (acfmenupanel.GearboxData[Table.id].GearTable[-2] or 0) != 0 then
 			ACF_GearsSlider(2, acfmenupanel.GearboxData[Table.id].GearTable[2], Table.id)
 			ACF_GearsSlider(3, acfmenupanel.GearboxData[Table.id].GearTable[-3], Table.id, "Min Target RPM",true)
@@ -63,18 +63,18 @@ if CLIENT then
 				end
 			end
 		end
-		
+
 		acfmenupanel:CPanelText("Desc", Table.desc)
 		acfmenupanel:CPanelText("MaxTorque", "Clutch Maximum Torque Rating : "..(Table.maxtq).."n-m / "..math.Round(Table.maxtq*0.73).."ft-lb")
 		acfmenupanel:CPanelText("Weight", "Weight : "..Table.weight.."kg")
-		
+
 		acfmenupanel.CustomDisplay:PerformLayout()
 		maxtorque = Table.maxtq
 	end
 
 	function ACF_GearsSlider(Gear, Value, ID, Desc, CVT)
 
-		if Gear and not acfmenupanel.CData[Gear] then	
+		if Gear and not acfmenupanel.CData[Gear] then
 			acfmenupanel.CData[Gear] = vgui.Create( "DNumSlider", acfmenupanel.CustomDisplay )
 				acfmenupanel.CData[Gear]:SetText( Desc or "Gear "..Gear )
 				acfmenupanel.CData[Gear].Label:SizeToContents()
@@ -94,19 +94,19 @@ if CLIENT then
 		end
 
 	end
-	
+
 	return
-	
+
 end
 
 function ENT:Initialize()
-	
+
 	self.IsGeartrain = true
 	self.Master = {}
 	self.IsMaster = true
-	
+
 	self.WheelLink = {} -- a "Link" has these components: Ent, Side, Axis, Rope, RopeLen, Output, ReqTq, Vel
-	
+
 	self.TotalReqTq = 0
 	self.RClutch = 0
 	self.LClutch = 0
@@ -117,9 +117,9 @@ function ENT:Initialize()
 	self.Gear = 1
 	self.GearRatio = 0
 	self.ChangeFinished = 0
-	
+
 	self.LegalThink = 0
-	
+
 	self.RPM = {}
 	self.CurRPM = 0
     self.CVT = false
@@ -128,13 +128,13 @@ function ENT:Initialize()
 	self.CanUpdate = true
 	self.LastActive = 0
 	self.Legal = true
-	
-end  
+
+end
 
 function MakeACF_Gearbox(Owner, Pos, Angle, Id, Data1, Data2, Data3, Data4, Data5, Data6, Data7, Data8, Data9, Data10)
 
 	if not Owner:CheckLimit("_acf_misc") then return false end
-	
+
 	local Gearbox = ents.Create("acf_gearbox")
 	local List = list.Get("ACFEnts")
 	local Classes = list.Get("ACFClasses")
@@ -154,13 +154,13 @@ function MakeACF_Gearbox(Owner, Pos, Angle, Id, Data1, Data2, Data3, Data4, Data
 	Gearbox.Dual = List.Mobility[Id].doubleclutch
     Gearbox.CVT = List.Mobility[Id].cvt
 	Gearbox.DoubleDiff = List.Mobility[Id].doublediff
-	
+
     if Gearbox.CVT then
 		Gearbox.TargetMinRPM = Data3
 		Gearbox.TargetMaxRPM = math.max(Data4,Data3+100)
 		Gearbox.CVTRatio = nil
 	end
-	
+
 	Gearbox.GearTable = List.Mobility[Id].geartable
 		Gearbox.GearTable.Final = Data10
 		Gearbox.GearTable[1] = Data1
@@ -173,7 +173,7 @@ function MakeACF_Gearbox(Owner, Pos, Angle, Id, Data1, Data2, Data3, Data4, Data
 		Gearbox.GearTable[8] = Data8
 		Gearbox.GearTable[9] = Data9
 		Gearbox.GearTable[0] = List.Mobility[Id].geartable[0]
-		
+
 		Gearbox.Gear0 = Data10
 		Gearbox.Gear1 = Data1
 		Gearbox.Gear2 = Data2
@@ -184,16 +184,16 @@ function MakeACF_Gearbox(Owner, Pos, Angle, Id, Data1, Data2, Data3, Data4, Data
 		Gearbox.Gear7 = Data7
 		Gearbox.Gear8 = Data8
 		Gearbox.Gear9 = Data9
-				
-	Gearbox:SetModel( Gearbox.Model )	
-		
+
+	Gearbox:SetModel( Gearbox.Model )
+
 	local Inputs = {"Gear","Gear Up","Gear Down"}
 	if Gearbox.CVT then
 		table.insert(Inputs,"CVT Ratio")
 	elseif Gearbox.DoubleDiff then
 		table.insert(Inputs, "Steer Rate")
 	end
-	
+
 	if Gearbox.Dual then
 		table.insert(Inputs, "Left Clutch")
 		table.insert(Inputs, "Right Clutch")
@@ -203,7 +203,7 @@ function MakeACF_Gearbox(Owner, Pos, Angle, Id, Data1, Data2, Data3, Data4, Data
 		table.insert(Inputs, "Clutch")
 		table.insert(Inputs, "Brake")
 	end
-	
+
     local Outputs = { "Ratio", "Entity", "Current Gear" }
     local OutputTypes = { "NORMAL", "ENTITY", "NORMAL" }
     if Gearbox.CVT then
@@ -211,68 +211,70 @@ function MakeACF_Gearbox(Owner, Pos, Angle, Id, Data1, Data2, Data3, Data4, Data
         table.insert(Outputs,"Max Target RPM")
         table.insert(OutputTypes,"NORMAL")
     end
-	
+
 	Gearbox.Inputs = Wire_CreateInputs( Gearbox, Inputs )
 	Gearbox.Outputs = WireLib.CreateSpecialOutputs( Gearbox, Outputs, OutputTypes )
 	Wire_TriggerOutput(Gearbox, "Entity", Gearbox)
-	
+
     if Gearbox.CVT then
 		Wire_TriggerOutput(Gearbox, "Min Target RPM", Gearbox.TargetMinRPM)
 		Wire_TriggerOutput(Gearbox, "Max Target RPM", Gearbox.TargetMaxRPM)
 	end
-	
+
 	Gearbox.LClutch = Gearbox.MaxTorque
 	Gearbox.RClutch = Gearbox.MaxTorque
 
-	Gearbox:PhysicsInit( SOLID_VPHYSICS )      	
-	Gearbox:SetMoveType( MOVETYPE_VPHYSICS )     	
+	Gearbox:PhysicsInit( SOLID_VPHYSICS )
+	Gearbox:SetMoveType( MOVETYPE_VPHYSICS )
 	Gearbox:SetSolid( SOLID_VPHYSICS )
 
-	local phys = Gearbox:GetPhysicsObject()  	
-	if IsValid( phys ) then 
-		phys:SetMass( Gearbox.Mass ) 
+	local phys = Gearbox:GetPhysicsObject()
+	if IsValid( phys ) then
+		if ACF.Weightable:GetBool() == false then
+			phys:SetMass( Gearbox.Mass )
+		end
 	end
-	
+
 	Gearbox.In = Gearbox:WorldToLocal(Gearbox:GetAttachment(Gearbox:LookupAttachment( "input" )).Pos)
 	Gearbox.OutL = Gearbox:WorldToLocal(Gearbox:GetAttachment(Gearbox:LookupAttachment( "driveshaftL" )).Pos)
 	Gearbox.OutR = Gearbox:WorldToLocal(Gearbox:GetAttachment(Gearbox:LookupAttachment( "driveshaftR" )).Pos)
-	
+
 	Owner:AddCount("_acf_gearbox", Gearbox)
 	Owner:AddCleanup( "acfmenu", Gearbox )
-	
+
 	Gearbox:ChangeGear(1)
-	
+
 	if Gearbox.Dual or Gearbox.DoubleDiff then
 		Gearbox:SetBodygroup(1, 1)
 	else
 		Gearbox:SetBodygroup(1, 0)
 	end
-	
+
 	Gearbox:SetNWString( "WireName", List.Mobility[Id].name )
 	Gearbox:UpdateOverlayText()
-		
+
 	return Gearbox
 end
 list.Set( "ACFCvars", "acf_gearbox", {"id", "data1", "data2", "data3", "data4", "data5", "data6", "data7", "data8", "data9", "data10"} )
 duplicator.RegisterEntityClass("acf_gearbox", MakeACF_Gearbox, "Pos", "Angle", "Id", "Gear1", "Gear2", "Gear3", "Gear4", "Gear5", "Gear6", "Gear7", "Gear8", "Gear9", "Gear0" )
 
 function ENT:Update( ArgsTable )
-	-- That table is the player data, as sorted in the ACFCvars above, with player who shot, 
+	-- That table is the player data, as sorted in the ACFCvars above, with player who shot,
 	-- and pos and angle of the tool trace inserted at the start
-	
+
 	if ArgsTable[1] ~= self.Owner then -- Argtable[1] is the player that shot the tool
 		return false, "You don't own that gearbox!"
 	end
-	
+
 	local Id = ArgsTable[4]	-- Argtable[4] is the engine ID
 	local List = list.Get("ACFEnts")
-	
+
 	if List.Mobility[Id].model ~= self.Model then
 		return false, "The new gearbox must have the same model!"
 	end
-		
+
 	if self.Id != Id then
-	
+
 		self.Id = Id
 		self.Mass = List.Mobility[Id].weight
 		self.SwitchTime = List.Mobility[Id].switch
@@ -281,14 +283,14 @@ function ENT:Update( ArgsTable )
 		self.Dual = List.Mobility[Id].doubleclutch
         self.CVT = List.Mobility[Id].cvt
 		self.DoubleDiff = List.Mobility[Id].doublediff
-		
+
 		local Inputs = {"Gear","Gear Up","Gear Down"}
 		if self.CVT then
 			table.insert(Inputs,"CVT Ratio")
 		elseif self.DoubleDiff then
 			table.insert(Inputs, "Steer Rate")
 		end
-	
+
 		if self.Dual then
 			table.insert(Inputs, "Left Clutch")
 			table.insert(Inputs, "Right Clutch")
@@ -298,7 +300,7 @@ function ENT:Update( ArgsTable )
 			table.insert(Inputs, "Clutch")
 			table.insert(Inputs, "Brake")
 		end
-		
+
 		local Outputs = { "Ratio", "Entity", "Current Gear" }
 		local OutputTypes = { "NORMAL", "ENTITY", "NORMAL" }
 		if self.CVT then
@@ -306,25 +308,27 @@ function ENT:Update( ArgsTable )
 			table.insert(Outputs,"Max Target RPM")
 			table.insert(OutputTypes,"NORMAL")
 		end
-		
-		local phys = self:GetPhysicsObject()    
-		if IsValid( phys ) then 
-			phys:SetMass( self.Mass ) 
+
+		local phys = self:GetPhysicsObject()
+		if IsValid( phys ) then
+			if ACF.Weightable:GetBool() == false then
+				phys:SetMass( self.Mass )
+			end
 		end
-		
+
 		self.Inputs = Wire_CreateInputs( self, Inputs )
         self.Outputs = WireLib.CreateSpecialOutputs( self, Outputs, OutputTypes )
         Wire_TriggerOutput( self, "Entity", self )
 	end
-    
-    if self.CVT then 
+
+    if self.CVT then
         self.TargetMinRPM = ArgsTable[7]
         self.TargetMaxRPM = math.max(ArgsTable[8],ArgsTable[7]+100)
 		self.CVTRatio = nil
 		Wire_TriggerOutput(self, "Min Target RPM", self.TargetMinRPM)
 		Wire_TriggerOutput(self, "Max Target RPM", self.TargetMaxRPM)
     end
-	
+
 	self.GearTable.Final = ArgsTable[14]
 	self.GearTable[1] = ArgsTable[5]
 	self.GearTable[2] = ArgsTable[6]
@@ -336,7 +340,7 @@ function ENT:Update( ArgsTable )
 	self.GearTable[8] = ArgsTable[12]
 	self.GearTable[9] = ArgsTable[13]
 	self.GearTable[0] = List.Mobility[Id].geartable[0]
-	
+
 	self.Gear0 = ArgsTable[14]
 	self.Gear1 = ArgsTable[5]
 	self.Gear2 = ArgsTable[6]
@@ -347,25 +351,25 @@ function ENT:Update( ArgsTable )
 	self.Gear7 = ArgsTable[11]
 	self.Gear8 = ArgsTable[12]
 	self.Gear9 = ArgsTable[13]
-	
+
 	self:ChangeGear(1)
-	
+
 	if self.Dual or self.DoubleDiff then
 		self:SetBodygroup(1, 1)
 	else
 		self:SetBodygroup(1, 0)
-	end	
-	
+	end
+
 	self:SetNWString( "WireName", List.Mobility[Id].name )
 	self:UpdateOverlayText()
-	
+
 	return true, "Gearbox updated successfully!"
 end
 
 function ENT:UpdateOverlayText()
-	
+
 	local text = ""
-	
+
 	if self.CVT then
 		text = "Gear 2: " .. math.Round( self.GearTable[ 2 ], 2 ) -- maybe a better name than "gear 2"...?
 		text = text .. "\nTarget: " .. math.Round( self.TargetMinRPM ) .. " - " .. math.Round( self.TargetMaxRPM ) .. " RPM\n"
@@ -374,12 +378,12 @@ function ENT:UpdateOverlayText()
 			text = text .. "Gear " .. i .. ": " .. math.Round( self.GearTable[ i ], 2 ) .. "\n"
 		end
 	end
-	
+
 	text = text .. "Final Drive: " .. math.Round( self.Gear0, 2 ) .. "\n"
 	text = text .. "Torque Rating: " .. self.MaxTorque .. " Nm / " .. math.Round( self.MaxTorque * 0.73 ) .. " ft-lb"
-	
+
 	self:SetOverlayText( text )
-	
+
 end
 
 
@@ -420,75 +424,78 @@ function ENT:TriggerInput( iname, value )
 		self.CVTRatio = math.Clamp(value,0,1)
 	elseif ( iname == "Steer Rate" ) then
 		self.SteerRate = math.Clamp(value,-1,1)
-	end		
+	end
 
 end
 
 function ENT:Think()
-	
+
 	local Time = CurTime()
-	
+
 	if self.LastActive + 2 > Time then
 		self:CheckRopes()
 	end
-	
+
 	self.Legal = self:CheckLegal()
-	
+
 	self:NextThink( Time + math.random( 5, 10 ) )
 	return true
-	
+
 end
 
 function ENT:CheckLegal()
-	
+
 	-- make sure weight is not below stock
-	if self:GetPhysicsObject():GetMass() < self.Mass then return false end
-	
+	if self:GetPhysicsObject():GetMass() < self.Mass and ACF.Weightable:GetBool() == false then return false end
+
+	-- parenting restriction should apply to all entities
+	if ACF.Parentable:GetBool() then return true end
+
 	-- if it's not parented we're fine
 	if not IsValid( self:GetParent() ) then return true end
-	
+
 	-- but not if it's parented to a parented prop
 	if IsValid( self:GetParent():GetParent() ) then return false end
-	
+
 	-- parenting is only legal if it's also welded
 	for k, v in pairs( constraint.FindConstraints( self, "Weld" ) ) do
-		
+
 		if v.Ent1 == self:GetParent() or v.Ent2 == self:GetParent() then return true end
-		
+
 	end
-	
+
 	return false
-	
+
 end
 
 function ENT:CheckRopes()
 
 	for Key, Link in pairs( self.WheelLink ) do
-	
+
 		local Ent = Link.Ent
-		
+
 		-- make sure the rope is still there
-		if not IsValid( Link.Rope ) then 
+		if not IsValid( Link.Rope ) then
 			self:Unlink( Ent )
 		continue end
-		
+
 		local OutPos = self:LocalToWorld( Link.Output )
 		local InPos = Ent:GetPos()
 		if Ent.IsGeartrain then
 			InPos = Ent:LocalToWorld( Ent.In )
 		end
-		
+
 		-- make sure it is not stretched too far
 		if OutPos:Distance( InPos ) > Link.RopeLen * 1.5 then
 			self:Unlink( Ent )
 		continue end
-		
+
 		-- make sure the angle is not excessive
 		local DrvAngle = ( OutPos - InPos ):GetNormalized():DotProduct( ( self:GetRight() * Link.Output.y ):GetNormalized() )
 		if DrvAngle < 0.7 then
 			self:Unlink( Ent )
 		end
-		
+
 	end
 
 end
@@ -496,9 +503,9 @@ end
 -- Check if every entity we are linked to still actually exists
 -- and remove any links that are invalid.
 function ENT:CheckEnts()
-	
+
 	for Key, Link in pairs( self.WheelLink ) do
-	
+
 		if not IsValid( Link.Ent ) then
 			table.remove( self.WheelLink, Key )
 		continue end
@@ -508,9 +515,9 @@ function ENT:CheckEnts()
 			Link.Ent:Remove()
 			table.remove( self.WheelLink, Key )
 		end
-		
+
 	end
-	
+
 end
 
 function ENT:Calc( InputRPM, InputInertia )
@@ -518,30 +525,30 @@ function ENT:Calc( InputRPM, InputInertia )
 	if self.LastActive == CurTime() then
 		return math.min( self.TotalReqTq, self.MaxTorque )
 	end
-	
+
 	if self.ChangeFinished < CurTime() then
 		self.InGear = true
 	end
-	
+
 	self:CheckEnts()
 
 	local BoxPhys = self:GetPhysicsObject()
 	local SelfWorld = self:LocalToWorld( BoxPhys:GetAngleVelocity() ) - self:GetPos()
-	
+
 	self.TotalReqTq = 0
-	
+
 	for Key, Link in pairs( self.WheelLink ) do
 		if not IsValid( Link.Ent ) then
 			table.remove( self.WheelLink, Key )
 		continue end
-		
+
 		local Clutch = 0
 		if Link.Side == 0 then
 			Clutch = self.LClutch
 		elseif Link.Side == 1 then
 			Clutch = self.RClutch
 		end
-	
+
 		if self.CVT and self.Gear == 1 then
 			if self.CVTRatio and self.CVTRatio > 0 then
 				self.GearTable[1] = math.Clamp(self.CVTRatio,0.01,1)
@@ -550,9 +557,9 @@ function ENT:Calc( InputRPM, InputInertia )
 			end
 			self.GearRatio = (self.GearTable[1] or 0)*self.GearTable.Final
 			Wire_TriggerOutput(self, "Ratio", self.GearRatio)
-		end		
-		
-	
+		end
+
+
 		Link.ReqTq = 0
 		if Link.Ent.IsGeartrain then
 			if not Link.Ent.Legal then continue end
@@ -563,13 +570,13 @@ function ENT:Calc( InputRPM, InputInertia )
 			local RPM = self:CalcWheel( Link, SelfWorld )
 			if self.GearRatio ~= 0 and ( ( InputRPM > 0 and RPM < InputRPM ) or ( InputRPM < 0 and RPM > InputRPM ) ) then
 				local NTq = math.min( Clutch, ( InputRPM - RPM) * InputInertia)
-			
+
 				if( self.SteerRate ~= 0 ) then
 					Sign = self.SteerRate / math.abs( self.SteerRate )
 				else
 					Sign = 0
 				end
-				if Link.Side == 0 then 
+				if Link.Side == 0 then
 						local DTq = math.Clamp( ( self.SteerRate * ( ( InputRPM * ( math.abs( self.SteerRate ) + 1 ) ) - (RPM * Sign) ) ) * InputInertia, -self.MaxTorque, self.MaxTorque )
 					Link.ReqTq = ( NTq + DTq )
 				elseif Link.Side == 1 then
@@ -585,9 +592,9 @@ function ENT:Calc( InputRPM, InputInertia )
 		end
 		self.TotalReqTq = self.TotalReqTq + math.abs( Link.ReqTq )
 	end
-			
+
 	return math.min( self.TotalReqTq, self.MaxTorque )
-	
+
 end
 
 function ENT:CalcWheel( Link, SelfWorld )
@@ -597,69 +604,69 @@ function ENT:CalcWheel( Link, SelfWorld )
 	local VelDiff = ( Wheel:LocalToWorld( WheelPhys:GetAngleVelocity() ) - Wheel:GetPos() ) - SelfWorld
 	local BaseRPM = VelDiff:Dot( Wheel:LocalToWorld( Link.Axis ) - Wheel:GetPos() )
 	Link.Vel = BaseRPM
-	
+
 	if self.GearRatio == 0 then return 0 end
-	
+
 	-- Reported BaseRPM is in angle per second and in the wrong direction, so we convert and add the gearratio
 	return BaseRPM / self.GearRatio / -6
-	
+
 end
 
 function ENT:Act( Torque, DeltaTime, MassRatio )
-	
-	local ReactTq = 0	
+
+	local ReactTq = 0
 	-- Calculate the ratio of total requested torque versus what's avaliable, and then multiply it but the current gearratio
 	local AvailTq = 0
 	if Torque ~= 0 then
 		AvailTq = math.min( math.abs( Torque ) / self.TotalReqTq, 1 ) / self.GearRatio * -( -Torque / math.abs( Torque ) )
 	end
-	
+
 	for Key, Link in pairs( self.WheelLink ) do
-		
+
 		local Brake = 0
 		if Link.Side == 0 then
 			Brake = self.LBrake
 		elseif Link.Side == 1 then
 			Brake = self.RBrake
 		end
-		
+
 		if Link.Ent.IsGeartrain then
 			Link.Ent:Act( Link.ReqTq * AvailTq, DeltaTime, MassRatio )
 		else
 			self:ActWheel( Link, Link.ReqTq * AvailTq, Brake, DeltaTime )
 			ReactTq = ReactTq + Link.ReqTq * AvailTq
 		end
-		
+
 	end
-	
+
 	local BoxPhys = self:GetPhysicsObject()
-	if IsValid( BoxPhys ) and ReactTq ~= 0 then	
+	if IsValid( BoxPhys ) and ReactTq ~= 0 then
 		local Force = self:GetForward() * ReactTq * MassRatio - self:GetForward()
 		BoxPhys:ApplyForceOffset( Force * 39.37 * DeltaTime, self:GetPos() + self:GetUp() * -39.37 )
 		BoxPhys:ApplyForceOffset( Force * -39.37 * DeltaTime, self:GetPos() + self:GetUp() * 39.37 )
 	end
-	
+
 	self.LastActive = CurTime()
-	
+
 end
 
 function ENT:ActWheel( Link, Torque, Brake, DeltaTime )
-	
+
 	local Phys = Link.Ent:GetPhysicsObject()
 	local Pos = Link.Ent:GetPos()
 	local TorqueAxis = Link.Ent:LocalToWorld( Link.Axis ) - Pos
 	local Cross = TorqueAxis:Cross( Vector( TorqueAxis.y, TorqueAxis.z, TorqueAxis.x ) )
 	local TorqueVec = TorqueAxis:Cross( Cross ):GetNormalized()
-	
+
 	local BrakeMult = 0
 	if Brake > 0 then
 		BrakeMult = Link.Vel * Phys:GetInertia() * Brake / 10
 	end
-	
+
 	local Force = TorqueVec * Torque * 0.75 + TorqueVec * BrakeMult
 	Phys:ApplyForceOffset( Force * -39.37 * DeltaTime, Pos + Cross * 39.37 )
 	Phys:ApplyForceOffset( Force * 39.37 * DeltaTime, Pos + Cross * -39.37 )
-	
+
 end
 
 function ENT:ChangeGear(value)
@@ -668,11 +675,11 @@ function ENT:ChangeGear(value)
 	self.GearRatio = (self.GearTable[self.Gear] or 0)*self.GearTable.Final
 	self.ChangeFinished = CurTime() + self.SwitchTime
 	self.InGear = false
-	
+
 	Wire_TriggerOutput(self, "Current Gear", self.Gear)
 	self:EmitSound("buttons/lever7.wav",250,100)
 	Wire_TriggerOutput(self, "Ratio", self.GearRatio)
-	
+
 end
 
 function ENT:Link( Target )
@@ -680,21 +687,21 @@ function ENT:Link( Target )
 	if not IsValid( Target ) or not table.HasValue( { "prop_physics", "acf_gearbox", "tire" }, Target:GetClass() ) then
 		return false, "Can only link props or gearboxes!"
 	end
-	
+
 	-- Check if target is already linked
 	for Key, Link in pairs( self.WheelLink ) do
-		if Link.Ent == Target then 
+		if Link.Ent == Target then
 			return false, "That is already linked to this gearbox!"
 		end
 	end
-	
+
 	-- make sure the angle is not excessive
 	local InPos = Vector( 0, 0, 0 )
 	if Target.IsGeartrain then
 		InPos = Target.In
 	end
 	local InPosWorld = Target:LocalToWorld( InPos )
-	
+
 	local OutPos = self.OutR
 	local Side = 1
 	if self:WorldToLocal( InPosWorld ).y < 0 then
@@ -702,14 +709,14 @@ function ENT:Link( Target )
 		Side = 0
 	end
 	local OutPosWorld = self:LocalToWorld( OutPos )
-	
+
 	local DrvAngle = ( OutPosWorld - InPosWorld ):GetNormalized():DotProduct( ( self:GetRight() * OutPos.y ):GetNormalized() )
 	if DrvAngle < 0.7 then
 		return false, "Cannot link due to excessive driveshaft angle!"
 	end
-	
+
 	local Rope = constraint.CreateKeyframeRope( OutPosWorld, 1, "cable/cable2", nil, self, OutPos, 0, Target, InPos, 0 )
-	
+
 	local Link = {
 		Ent = Target,
 		Side = Side,
@@ -721,70 +728,70 @@ function ENT:Link( Target )
 		Vel = 0
 	}
 	table.insert( self.WheelLink, Link )
-	
+
 	return true, "Link successful!"
-	
+
 end
 
 function ENT:Unlink( Target )
-	
+
 	for Key, Link in pairs( self.WheelLink ) do
-		
+
 		if Link.Ent == Target then
-			
+
 			-- Remove any old physical ropes leftover from dupes
 			for Key, Rope in pairs( constraint.FindConstraints( Link.Ent, "Rope" ) ) do
 				if Rope.Ent1 == self or Rope.Ent2 == self then
 					Rope.Constraint:Remove()
 				end
 			end
-			
+
 			if IsValid( Link.Rope ) then
 				Link.Rope:Remove()
 			end
-			
+
 			table.remove( self.WheelLink, Key )
-			
+
 			return true, "Unlink successful!"
-			
+
 		end
-		
+
 	end
-	
+
 	return false, "That entity is not linked to this gearbox!"
-	
+
 end
 
 function ENT:PreEntityCopy()
-	
+
 	-- Link Saving
 	local info = {}
 	local entids = {}
-	
+
 	-- Clean the table of any invalid entities
 	for Key, Link in pairs( self.WheelLink ) do
 		if not IsValid( Link.Ent ) then
 			table.remove( self.WheelLink, Key )
 		end
 	end
-	
+
 	-- Then save it
 	for Key, Link in pairs( self.WheelLink ) do
 		table.insert( entids, Link.Ent:EntIndex() )
 	end
-	
+
 	info.entities = entids
 	if info.entities then
 		duplicator.StoreEntityModifier( self, "WheelLink", info )
 	end
-	
+
 	//Wire dupe info
 	self.BaseClass.PreEntityCopy( self )
-	
+
 end
 
 function ENT:PostEntityPaste( Player, Ent, CreatedEntities )
-	
+
 	-- Link Pasting
 	if Ent.EntityMods and Ent.EntityMods.WheelLink and Ent.EntityMods.WheelLink.entities then
 		local WheelLink = Ent.EntityMods.WheelLink
@@ -800,7 +807,7 @@ function ENT:PostEntityPaste( Player, Ent, CreatedEntities )
 		end
 		Ent.EntityMods.WheelLink = nil
 	end
-	
+
 	//Wire dupe info
 	self.BaseClass.PostEntityPaste( self, Player, Ent, CreatedEntities )
 
@@ -813,6 +820,6 @@ function ENT:OnRemove()
 			self.Master[Key]:Unlink( self )
 		end
 	end
-	
+
 end
 

--- a/lua/entities/acf_gun.lua
+++ b/lua/entities/acf_gun.lua
@@ -11,9 +11,9 @@ if CLIENT then
 	local ACF_GunInfoWhileSeated = CreateClientConVar("ACF_GunInfoWhileSeated", 0, true, false)
 
 	function ENT:Initialize()
-		
+
 		self.BaseClass.Initialize( self )
-		
+
 		self.LastFire = 0
 		self.Reload = 1
 		self.CloseTime = 1
@@ -21,29 +21,29 @@ if CLIENT then
 		self.RateScale = 1
 		self.FireAnim = self:LookupSequence( "shoot" )
 		self.CloseAnim = self:LookupSequence( "load" )
-		
+
 	end
-	
+
 	-- copied from base_wire_entity: DoNormalDraw's notip arg isn't accessible from ENT:Draw defined there.
 	function ENT:Draw()
-	
+
 		local lply = LocalPlayer()
 		local hideBubble = not ACF_GunInfoWhileSeated:GetBool() and IsValid(lply) and lply:InVehicle()
-		
+
 		self.BaseClass.DoNormalDraw(self, false, hideBubble)
 		Wire_Render(self)
-		
-		if self.GetBeamLength and (not self.GetShowBeam or self:GetShowBeam()) then 
+
+		if self.GetBeamLength and (not self.GetShowBeam or self:GetShowBeam()) then
 			-- Every SENT that has GetBeamLength should draw a tracer. Some of them have the GetShowBeam boolean
-			Wire_DrawTracerBeam( self, 1, self.GetBeamHighlight and self:GetBeamHighlight() or false ) 
+			Wire_DrawTracerBeam( self, 1, self.GetBeamHighlight and self:GetBeamHighlight() or false )
 		end
-		
+
 	end
-	
+
 	function ENT:Think()
-		
+
 		self.BaseClass.Think( self )
-		
+
 		local SinceFire = CurTime() - self.LastFire
 		self:SetCycle( SinceFire * self.Rate / self.RateScale )
 		if CurTime() > self.LastFire + self.CloseTime and self.CloseAnim then
@@ -52,18 +52,18 @@ if CLIENT then
 			self.Rate = 1 / ( self.Reload - self.CloseTime ) -- Base anim time is 1s, rate is in 1/10 of a second
 			self:SetPlaybackRate( self.Rate )
 		end
-		
+
 	end
-	
+
 	function ENT:Animate( Class, ReloadTime, LoadOnly )
-		
+
 		if self.CloseAnim and self.CloseAnim > 0 then
 			self.CloseTime = math.max(ReloadTime-0.75,ReloadTime*0.75)
 		else
 			self.CloseTime = ReloadTime
 			self.CloseAnim = nil
 		end
-		
+
 		self:ResetSequence( self.FireAnim )
 		self:SetCycle( 0 )
 		self.RateScale = self:SequenceDuration()
@@ -75,13 +75,13 @@ if CLIENT then
 		self:SetPlaybackRate( self.Rate )
 		self.LastFire = CurTime()
 		self.Reload = ReloadTime
-		
+
 	end
 
 	function ACFGunGUICreate( Table )
-			
+
 		acfmenupanel:CPanelText("Name", Table.name)
-		
+
 		acfmenupanel.CData.DisplayModel = vgui.Create( "DModelPanel", acfmenupanel.CustomDisplay )
 			acfmenupanel.CData.DisplayModel:SetModel( Table.model )
 			acfmenupanel.CData.DisplayModel:SetCamPos( Vector( 250, 500, 250 ) )
@@ -90,26 +90,26 @@ if CLIENT then
 			acfmenupanel.CData.DisplayModel:SetSize(acfmenupanel:GetWide(),acfmenupanel:GetWide())
 			acfmenupanel.CData.DisplayModel.LayoutEntity = function( panel, entity ) end
 		acfmenupanel.CustomDisplay:AddItem( acfmenupanel.CData.DisplayModel )
-		
-		acfmenupanel:CPanelText("ClassDesc", list.Get("ACFClasses").GunClass[Table.gunclass].desc)	
+
+		acfmenupanel:CPanelText("ClassDesc", list.Get("ACFClasses").GunClass[Table.gunclass].desc)
 		acfmenupanel:CPanelText("GunDesc", Table.desc)
 		acfmenupanel:CPanelText("Caliber", "Caliber : "..(Table.caliber*10).."mm")
 		acfmenupanel:CPanelText("Weight", "Weight : "..Table.weight.."kg")
-		
+
 		if Table.canparent then
 			acfmenupanel:CPanelText("GunParentable", "\nThis weapon can be parented.")
 		end
-		
+
 		acfmenupanel.CustomDisplay:PerformLayout()
-		
+
 	end
-	
+
 	return
-	
+
 end
 
 function ENT:Initialize()
-		
+
 	self.ReloadTime = 1
 	self.Ready = true
 	self.Firing = nil
@@ -120,24 +120,25 @@ function ENT:Initialize()
 	self.LastLoadDuration = 0
 	self.Owner = self
 	self.Parentable = false
-	
+	self.Legal = true
+
 	self.IsMaster = true
 	self.AmmoLink = {}
 	self.CurAmmo = 1
 	self.Sequence = 1
-	
+
 	self.BulletData = {}
 		self.BulletData.Type = "Empty"
 		self.BulletData.PropMass = 0
 		self.BulletData.ProjMass = 0
-	
+
 	self.Inaccuracy 	= 1
-	
+
 	self.Inputs = Wire_CreateInputs( self, { "Fire", "Unload", "Reload" } )
 	self.Outputs = WireLib.CreateSpecialOutputs( self, { "Ready", "AmmoCount", "Entity", "Shots Left", "Fire Rate", "Muzzle Weight", "Muzzle Velocity" }, { "NORMAL", "NORMAL", "ENTITY", "NORMAL", "NORMAL", "NORMAL", "NORMAL" } )
 	Wire_TriggerOutput(self, "Entity", self)
 
-end  
+end
 
 function MakeACF_Gun(Owner, Pos, Angle, Id)
 
@@ -145,13 +146,13 @@ function MakeACF_Gun(Owner, Pos, Angle, Id)
 	local List = list.Get("ACFEnts")
 	if List.Guns[Id] then EID = Id else EID = "50mmC" end
 	local Lookup = List.Guns[EID]
-	
+
 	if Lookup.gunclass == "SL" then
 		if not Owner:CheckLimit("_acf_smokelauncher") then return false end
 	else
 		if not Owner:CheckLimit("_acf_gun") then return false end
 	end
-	
+
 	local Gun = ents.Create("acf_gun")
 	local ClassData = list.Get("ACFClasses").GunClass[Lookup.gunclass]
 	if not Gun:IsValid() then return false end
@@ -184,7 +185,7 @@ function MakeACF_Gun(Owner, Pos, Angle, Id)
 	if(Lookup.magreload) then
 		Gun.MagReload = math.max(Gun.MagReload, Lookup.magreload)
 	end
-	
+
 	Gun:SetNWString( "WireName", Lookup.name )
 	Gun:SetNWString( "Class", Gun.Class )
 	Gun:SetNWString( "ID", Gun.Id )
@@ -194,15 +195,15 @@ function MakeACF_Gun(Owner, Pos, Angle, Id)
 	Gun.Sound = ClassData.sound
 	Gun:SetNWString( "Sound", Gun.Sound )
 	Gun.Inaccuracy = ClassData.spread
-	Gun:SetModel( Gun.Model )	
-	
-	Gun:PhysicsInit( SOLID_VPHYSICS )      	
-	Gun:SetMoveType( MOVETYPE_VPHYSICS )     	
+	Gun:SetModel( Gun.Model )
+
+	Gun:PhysicsInit( SOLID_VPHYSICS )
+	Gun:SetMoveType( MOVETYPE_VPHYSICS )
 	Gun:SetSolid( SOLID_VPHYSICS )
-	
+
 	local Muzzle = Gun:GetAttachment( Gun:LookupAttachment( "muzzle" ) )
 	Gun.Muzzle = Gun:WorldToLocal(Muzzle.Pos)
-	
+
 	local longbarrel = ClassData.longbarrel
 	if longbarrel ~= nil then
 		timer.Simple(0.25, function() --need to wait until after the property is actually set
@@ -212,7 +213,7 @@ function MakeACF_Gun(Owner, Pos, Angle, Id)
 			end
 		end)
 	end
-	
+
 	/*local Height = 30		--Damn you Garry
 	local Width = 30
 	local length = 105
@@ -227,9 +228,9 @@ function MakeACF_Gun(Owner, Pos, Angle, Id)
 			table.insert(Import, Vertex( Vec*Scale,0,0 ) )
 		end
 	end
-	PrintTable(Import)  
+	PrintTable(Import)
 	Gun:SetNWFloat( "Scale", Scale )
-	
+
 	local p1 = Vector(length/-2*Scale,Width/-2*Scale,Height/-2*Scale)
 	local p2 = Vector(length/-2*Scale,Width/2*Scale,Height/-2*Scale)
 	local p3 = Vector(length/2*Scale,Width/2*Scale,Height/-2*Scale)
@@ -238,7 +239,7 @@ function MakeACF_Gun(Owner, Pos, Angle, Id)
 	local p6 = Vector(length/-2*Scale,Width/2*Scale,Height/2*Scale)
 	local p7 = Vector(length/2*Scale,Width/2*Scale,Height/2*Scale)
 	local p8 = Vector(length/2*Scale,Width/-2*Scale,Height/2*Scale)
-	
+
 	local Vertices = {}
 	table.Add( Vertices, MeshQuad( p5, p6, p7, p8, 0 ) )
 	table.Add( Vertices, MeshQuad( p4, p3, p2, p1, 0 ) )
@@ -246,64 +247,64 @@ function MakeACF_Gun(Owner, Pos, Angle, Id)
 	table.Add( Vertices, MeshQuad( p6, p5, p1, p2, 0 ) )
 	table.Add( Vertices, MeshQuad( p5, p8, p4, p1, 0 ) )
 	table.Add( Vertices, MeshQuad( p7, p6, p2, p3, 0 ) )
-	
-	PrintTable(Vertices) 
+
+	PrintTable(Vertices)
 	Gun:PhysicsFromMesh( Import )*/
 
-	local phys = Gun:GetPhysicsObject()  	
+	local phys = Gun:GetPhysicsObject()
 	if IsValid( phys ) then
-		phys:SetMass( Gun.Mass ) 
-	end 
-	
+		phys:SetMass( Gun.Mass )
+	end
+
 	Gun:UpdateOverlayText()
-	
+
 	Owner:AddCleanup( "acfmenu", Gun )
-	
+
 	if Lookup.gunclass == "SL" then
 		Owner:AddCount("_acf_smokelauncher", Gun)
 	else
 		Owner:AddCount("_acf_gun", Gun)
 	end
-	
+
 	ACF_Activate(Gun, 0)
-	
+
 	return Gun
-	
+
 end
 list.Set( "ACFCvars", "acf_gun", {"id"} )
 duplicator.RegisterEntityClass("acf_gun", MakeACF_Gun, "Pos", "Angle", "Id")
 
 function ENT:UpdateOverlayText()
-	
+
 	local roundType = self.BulletData.Type
-	
-	if self.BulletData.Tracer and self.BulletData.Tracer > 0 then 
+
+	if self.BulletData.Tracer and self.BulletData.Tracer > 0 then
 		roundType = roundType .. "-T"
 	end
-	
+
 	local isEmpty = self.BulletData.Type == "Empty"
-	
+
 	local clipLeft = isEmpty and 0 or (self.MagSize - self.CurrentShot)
 	local ammoLeft = (self.Ammo or 0) + clipLeft
 	local isReloading = not isEmpty and CurTime() < self.NextFire and (self.MagSize == 1 or (self.LastLoadDuration > self.ReloadTime))
 	local gunStatus = isReloading and "reloading" or (clipLeft .. " in gun")
-	
+
 	--print(self.MagSize or "nil", isEmpty, clipLeft, self.CurrentShot)
-	
+
 	--print(self.LastLoadDuration, self.ReloadTime, self.LastLoadDuration > self.ReloadTime, gunStatus)
-	
+
 	local text = roundType .. " - " .. ammoLeft .. (ammoLeft == 1 and " shot left" or " shots left ( " .. gunStatus .. " )")
 	/*
 	local RoundData = ACF.RoundTypes[ self.BulletData.Type ]
-	
+
 	if RoundData and RoundData.cratetxt then
 		text = text .. "\n" .. RoundData.cratetxt( self.BulletData )
 	end
 	//*/
 	text = text .. "\nRounds Per Minute: " .. math.Round( self.RateOfFire or 0, 2 )
-	
+
 	self:SetOverlayText( text )
-	
+
 end
 
 function ENT:Link( Target )
@@ -312,40 +313,40 @@ function ENT:Link( Target )
 	if not IsValid( Target ) or Target:GetClass() ~= "acf_ammo" then
 		return false, "Guns can only be linked to ammo crates!"
 	end
-	
+
 	-- Don't link if it's not the right ammo type
 	if Target.BulletData.Id ~= self.Id then
 		--if not (self.Class == "AL" and string.find(Target.BulletData.Id, "mmC", 1, true)) then --allows AL to load cannon ammo
 			return false, "Wrong ammo type!"
 		--end
 	end
-	
+
 	-- Don't link if it's a refill crate
 	if Target.RoundType == "Refill" then
 		return false, "Refill crates cannot be linked!"
 	end
-	
+
 	-- Don't link if it's a blacklisted round type for this gun
 	local Blacklist = ACF.AmmoBlacklist[ Target.RoundType ] or {}
-	
+
 	if table.HasValue( Blacklist, self.Class ) then
 		return false, "That round type cannot be used with this gun!"
 	end
-	
+
 	-- Don't link if it's already linked
 	for k, v in pairs( self.AmmoLink ) do
 		if v == Target then
 			return false, "That crate is already linked to this gun!"
 		end
 	end
-	
+
 	table.insert( self.AmmoLink, Target )
 	table.insert( Target.Master, self )
-	
+
 	if self.BulletData.Type == "Empty" and Target.Load then
 		self:UnloadAmmo()
 	end
-	
+
 	self.ReloadTime = ( ( Target.BulletData.RoundVolume / 500 ) ^ 0.60 ) * self.RoFmod * self.PGRoFmod
 	self.RateOfFire = 60 / self.ReloadTime
 	Wire_TriggerOutput( self, "Fire Rate", self.RateOfFire )
@@ -353,7 +354,7 @@ function ENT:Link( Target )
 	Wire_TriggerOutput( self, "Muzzle Velocity", math.floor( Target.BulletData.MuzzleVel * ACF.VelScale ) )
 
 	return true, "Link successful!"
-	
+
 end
 
 function ENT:Unlink( Target )
@@ -365,13 +366,13 @@ function ENT:Unlink( Target )
 			Success = true
 		end
 	end
-	
+
 	if Success then
 		return true, "Unlink successful!"
 	else
 		return false, "That entity is not linked to this gun!"
 	end
-	
+
 end
 
 function ENT:CanProperty( ply, property )
@@ -389,8 +390,8 @@ function ENT:CanProperty( ply, property )
 				end
 			end)
 		end
-	end 
-	
+	end
+
 	return true
 
 end
@@ -409,37 +410,37 @@ function ENT:GetUser( inp )
 		end
 	elseif inp:GetClass() == "gmod_wire_keyboard" then
 		if inp.ply then
-			return inp.ply 
+			return inp.ply
 		end
 	elseif inp:GetClass() == "gmod_wire_joystick" then
-		if inp.Pod then 
+		if inp.Pod then
 			return inp.Pod:GetDriver()
 		end
 	elseif inp:GetClass() == "gmod_wire_joystick_multi" then
-		if inp.Pod then 
+		if inp.Pod then
 			return inp.Pod:GetDriver()
 		end
 	elseif inp:GetClass() == "gmod_wire_expression2" then
 		if inp.Inputs.Fire then
-			return self:GetUser(inp.Inputs.Fire.Src) 
+			return self:GetUser(inp.Inputs.Fire.Src)
 		elseif inp.Inputs.Shoot then
-			return self:GetUser(inp.Inputs.Shoot.Src) 
+			return self:GetUser(inp.Inputs.Shoot.Src)
 		elseif inp.Inputs then
 			for _,v in pairs(inp.Inputs) do
 				if v.Src then
 					if table.HasValue(WireTable, v.Src:GetClass()) then
-						return self:GetUser(v.Src) 
+						return self:GetUser(v.Src)
 					end
 				end
 			end
 		end
 	end
 	return inp.Owner or inp:GetOwner()
-	
+
 end
 
 function ENT:TriggerInput( iname, value )
-	
+
 	if (iname == "Unload" and value > 0) then
 		self:UnloadAmmo()
 	elseif ( iname == "Fire" and value > 0 and ACF.GunfireEnabled ) then
@@ -454,7 +455,7 @@ function ENT:TriggerInput( iname, value )
 		self.Firing = false
 	elseif ( iname == "Reload" and value ~= 0 ) then
 		self.Reloading = true
-	end		
+	end
 end
 
 local function RetDist( enta, entb )
@@ -472,7 +473,7 @@ function ENT:Think()
 		local CrateBonus = {}
 		local rofbonus = 0
 		local totalcap = 0
-		
+
 		for Key, Crate in pairs(self.AmmoLink) do
 			if IsValid( Crate ) and Crate.Load then
 				if RetDist( self, Crate ) < 512 then
@@ -486,45 +487,45 @@ function ENT:Think()
 				end
 			end
 		end
-		
+
 		for mul, cap in pairs(CrateBonus) do
-			rofbonus = rofbonus + (cap/totalcap)*mul 
+			rofbonus = rofbonus + (cap/totalcap)*mul
 		end
 
 		self.CrateBonus = rofbonus or 1
 		self.Ammo = Ammo
 		self:UpdateOverlayText()
-		
+
 		Wire_TriggerOutput(self, "AmmoCount", Ammo)
-		
-		
+
+
 		if( self.MagSize ) then
 			Wire_TriggerOutput(self, "Shots Left", self.MagSize - self.CurrentShot)
 		else
 			Wire_TriggerOutput(self, "Shots Left", 1)
 		end
-		
+
 		self:SetNWString("GunType",self.Id)
 		self:SetNWInt("Ammo",Ammo)
 		self:SetNWString("Type",self.BulletData.Type)
 		self:SetNWFloat("Mass",self.BulletData.ProjMass*100)
 		self:SetNWFloat("Propellant",self.BulletData.PropMass*1000)
 		self:SetNWFloat("FireRate",self.RateOfFire)
-		
+
 		self.LastSend = Time
-	
+
 	end
-	
+
 	if self.NextFire <= Time then
 		self.Ready = true
 		Wire_TriggerOutput(self, "Ready", 1)
-		
+
 		if self.MagSize and self.MagSize == 1 then
 			self.CurrentShot = 0
 		end
-		
+
 		if self.Firing then
-			self:FireShell()	
+			self:FireShell()
 		elseif self.Reloading then
 			self:ReloadMag()
 			self.Reloading = false
@@ -533,15 +534,38 @@ function ENT:Think()
 
 	self:NextThink(Time)
 	return true
-	
+
+end
+
+function ENT:CheckLegal()
+	if ISSITP then
+		if self.sitp_spacetype != "space" and self.sitp_spacetype != "planet" then
+			return false
+		elseif self.sitp_core == false then
+			return false
+		end
+	end
+	if ACF.Parentable:GetBool() == false then
+		if self:GetParent():IsValid() and not self.Parentable then
+			return false
+		end
+	end
+	if ACF.Weightable:GetBool() == false then
+		if self:GetPhysicsObject():GetMass() < self.Mass then
+			return false
+		elseif ISBNK then
+			return ENT:CheckWeight()
+		end
+	end
+	return true
 end
 
 function ENT:CheckWeight()
 	local mass = self:GetPhysicsObject():GetMass()
 	local maxmass = GetConVarNumber("bnk_maxweight") * 1000 + 999
-	
+
 	local chk = false
-	
+
 	local allents = constraint.GetAllConstrainedEntities( self )
 	for _, ent in pairs(allents) do
 		if (ent and ent:IsValid() and not ent:IsPlayer() and not (ent == self)) then
@@ -551,24 +575,18 @@ function ENT:CheckWeight()
 			end
 		end
 	end
-	
+
 	if( mass < maxmass ) then
 		chk = true
 	end
-	
+
 	return chk
 end
 
 function ENT:ReloadMag()
-	if(self.IsUnderWeight == nil) then
-		self.IsUnderWeight = true
-		if(ISBNK) then
-			self.IsUnderWeight = self:CheckWeight()
-		end
-	end
-	if ( (self.CurrentShot > 0) and self.IsUnderWeight and self.Ready and self:GetPhysicsObject():GetMass() >= self.Mass and not (self:GetParent():IsValid() and not self.Parentable) ) then
+	if (self.CurrentShot > 0 and self.Ready and self:CheckLegal()) then
 		if ( ACF.RoundTypes[self.BulletData.Type] ) then		--Check if the roundtype loaded actually exists
-			self:LoadAmmo(self.MagReload, false)	
+			self:LoadAmmo(self.MagReload, false)
 			self:EmitSound("weapons/357/357_reload4.wav",500,100)
 			self.CurrentShot = 0
 			Wire_TriggerOutput(self, "Ready", 0)
@@ -576,7 +594,7 @@ function ENT:ReloadMag()
 			self.CurrentShot = 0
 			self.Ready = false
 			Wire_TriggerOutput(self, "Ready", 0)
-			self:LoadAmmo(false, true)	
+			self:LoadAmmo(false, true)
 		end
 	end
 end
@@ -584,85 +602,70 @@ end
 function ENT:GetInaccuracy()
 	local SpreadScale = ACF.SpreadScale
 	local IaccMult = 1
-	
+
 	if (self.ACF.Health and self.ACF.MaxHealth) then
 		IaccMult = math.Clamp(((1 - SpreadScale) / (0.5)) * ((self.ACF.Health/self.ACF.MaxHealth) - 1) + 1, 1, SpreadScale)
 	end
-	
+
 	local coneAng = self.Inaccuracy * ACF.GunInaccuracyScale * IaccMult
-	
+
 	return coneAng
 end
 
 
 
 function ENT:FireShell()
-	
+
 	local CanDo = hook.Run("ACF_FireShell", self, self.BulletData )
 	if CanDo == false then return end
-	if(self.IsUnderWeight == nil) then
-		self.IsUnderWeight = true
-		if(ISBNK) then
-			self.IsUnderWeight = self:CheckWeight()
-		end
-	end
-	
-	local bool = true
-	if(ISSITP) then
-		if(self.sitp_spacetype != "space" and self.sitp_spacetype != "planet") then
-			bool = false
-		end
-		if(self.sitp_core == false) then
-			bool = false
-		end
-	end
-	if ( bool and self.IsUnderWeight and self.Ready and self:GetPhysicsObject():GetMass() >= self.Mass and not (self:GetParent():IsValid() and not self.Parentable) ) then
+
+	if (self.Ready and self:CheckLegal()) then
 		Blacklist = {}
 		if not ACF.AmmoBlacklist[self.BulletData.Type] then
 			Blacklist = {}
 		else
-			Blacklist = ACF.AmmoBlacklist[self.BulletData.Type]	
+			Blacklist = ACF.AmmoBlacklist[self.BulletData.Type]
 		end
 		if ( ACF.RoundTypes[self.BulletData.Type] and !table.HasValue( Blacklist, self.Class ) ) then		--Check if the roundtype loaded actually exists
-		
+
 			local MuzzlePos = self:LocalToWorld(self.Muzzle)
 			local MuzzleVec = self:GetForward()
-			
-			local coneAng = math.tan(math.rad(self:GetInaccuracy())) 
+
+			local coneAng = math.tan(math.rad(self:GetInaccuracy()))
 			local randUnitSquare = (self:GetUp() * (2 * math.random() - 1) + self:GetRight() * (2 * math.random() - 1))
 			local spread = randUnitSquare:GetNormalized() * coneAng * (math.random() ^ (1 / math.Clamp(ACF.GunInaccuracyBias, 0.5, 4)))
 			local ShootVec = (MuzzleVec + spread):GetNormalized()
-			
+
 			self:MuzzleEffect( MuzzlePos, MuzzleVec )
-			
+
 			self.BulletData.Pos = MuzzlePos
 			self.BulletData.Flight = ShootVec * self.BulletData.MuzzleVel * 39.37 + self:GetVelocity()
 			self.BulletData.Owner = self.User
 			self.BulletData.Gun = self
 			self.CreateShell = ACF.RoundTypes[self.BulletData.Type].create
 			self:CreateShell( self.BulletData )
-			
+
 			local HasPhys = constraint.FindConstraintEntity(self, "Weld"):IsValid() or not self:GetParent():IsValid()
 			ACF_KEShove(self, HasPhys and util.LocalToWorld(self, self:GetPhysicsObject():GetMassCenter(), 0) or self:GetPos(), -self:GetForward(), (self.BulletData.ProjMass * self.BulletData.MuzzleVel * 39.37 + self.BulletData.PropMass * 3000 * 39.37)*(GetConVarNumber("acf_recoilpush") or 1) )
-			
+
 			self.Ready = false
 			self.CurrentShot = math.min(self.CurrentShot + 1, self.MagSize)
 			if((self.CurrentShot >= self.MagSize) and (self.MagSize > 1)) then
-				self:LoadAmmo(self.MagReload, false)	
+				self:LoadAmmo(self.MagReload, false)
 				self:EmitSound("weapons/357/357_reload4.wav",500,100)
 				self.CurrentShot = 0
 			else
-				self:LoadAmmo(false, false)	
+				self:LoadAmmo(false, false)
 			end
 			Wire_TriggerOutput(self, "Ready", 0)
 		else
 			self.CurrentShot = 0
 			self.Ready = false
 			Wire_TriggerOutput(self, "Ready", 0)
-			self:LoadAmmo(false, true)	
+			self:LoadAmmo(false, true)
 		end
 	end
-	
+
 end
 
 function ENT:CreateShell()
@@ -674,21 +677,21 @@ function ENT:FindNextCrate()
 	local MaxAmmo = table.getn(self.AmmoLink)
 	local AmmoEnt = nil
 	local i = 0
-	
+
 	while i <= MaxAmmo and not (AmmoEnt and AmmoEnt:IsValid() and AmmoEnt.Ammo > 0) do
-		
+
 		self.CurAmmo = self.CurAmmo + 1
 		if self.CurAmmo > MaxAmmo then self.CurAmmo = 1 end
-		
+
 		AmmoEnt = self.AmmoLink[self.CurAmmo]
 		if AmmoEnt and AmmoEnt:IsValid() and AmmoEnt.Ammo > 0 and AmmoEnt.Load then
 			return AmmoEnt
 		end
 		AmmoEnt = nil
-		
+
 		i = i + 1
 	end
-	
+
 	return false
 end
 
@@ -696,55 +699,55 @@ function ENT:LoadAmmo( AddTime, Reload )
 
 	local AmmoEnt = self:FindNextCrate()
 	local curTime = CurTime()
-	
+
 	if AmmoEnt then
 		AmmoEnt.Ammo = AmmoEnt.Ammo - 1
 		self.BulletData = AmmoEnt.BulletData
 		self.BulletData.Crate = AmmoEnt:EntIndex()
-		
+
 		local cb = 1
 		if(self.CrateBonus and (self.MagReload == 0)) then
 			cb = self.CrateBonus
 			if (cb == 0) then cb = 1 end
 		end
-		
+
 		self.ReloadTime = ((self.BulletData.RoundVolume/500)^0.60)*self.RoFmod*self.PGRoFmod * cb
 		Wire_TriggerOutput(self, "Loaded", self.BulletData.Type)
-		
+
 		self.RateOfFire = (60/self.ReloadTime)
 		Wire_TriggerOutput(self, "Fire Rate", self.RateOfFire)
 		Wire_TriggerOutput(self, "Muzzle Weight", math.floor(self.BulletData.ProjMass*1000) )
 		Wire_TriggerOutput(self, "Muzzle Velocity", math.floor(self.BulletData.MuzzleVel*ACF.VelScale) )
-		
+
 		self.NextFire = curTime + self.ReloadTime
 		local reloadTime = self.ReloadTime
-		
+
 		if AddTime then
 			reloadTime = reloadTime + AddTime * self.CrateBonus
 		end
 		if Reload then
 			self:ReloadEffect()
 		end
-		
+
 		self.NextFire = curTime + reloadTime
 		self.LastLoadDuration = reloadTime
-		
+
 		self:Think()
-		return true	
+		return true
 	else
 		self.BulletData = {}
 			self.BulletData.Type = "Empty"
 			self.BulletData.PropMass = 0
 			self.BulletData.ProjMass = 0
-		
+
 		self:EmitSound("weapons/pistol/pistol_empty.wav",500,100)
 		Wire_TriggerOutput(self, "Loaded", "Empty")
-				
+
 		self.NextFire = curTime + 0.5
 		self:Think()
 	end
 	return false
-	
+
 end
 
 function ENT:UnloadAmmo()
@@ -753,7 +756,7 @@ function ENT:UnloadAmmo()
 	if Crate and Crate:IsValid() and self.BulletData.Type == Crate.BulletData.Type then
 		Crate.Ammo = Crate.Ammo+1
 	end
-	
+
 	self.Ready = false
 	Wire_TriggerOutput(self, "Ready", 0)
 	self:LoadAmmo( math.min(self.ReloadTime,math.max(self.ReloadTime - (self.NextFire - CurTime()),0) )	, true )
@@ -762,7 +765,7 @@ function ENT:UnloadAmmo()
 end
 
 function ENT:MuzzleEffect()
-	
+
 	local Effect = EffectData()
 		Effect:SetEntity( self )
 		Effect:SetScale( self.BulletData.PropMass )
@@ -780,7 +783,7 @@ function ENT:ReloadEffect()
 		Effect:SetMagnitude( self.ReloadTime )
 		Effect:SetSurfaceProp( ACF.RoundTypes[self.BulletData.Type].netid  )	--Encoding the ammo type into a table index
 	util.Effect( "ACF_MuzzleFlash", Effect, true, true )
-	
+
 end
 
 function ENT:PreEntityCopy()
@@ -799,10 +802,10 @@ function ENT:PreEntityCopy()
 	if info.entities then
 		duplicator.StoreEntityModifier( self, "ACFAmmoLink", info )
 	end
-	
+
 	//Wire dupe info
 	self.BaseClass.PreEntityCopy( self )
-	
+
 end
 
 function ENT:PostEntityPaste( Player, Ent, CreatedEntities )
@@ -819,7 +822,7 @@ function ENT:PostEntityPaste( Player, Ent, CreatedEntities )
 		end
 		Ent.EntityMods.ACFAmmoLink = nil
 	end
-	
+
 	//Wire dupe info
 	self.BaseClass.PostEntityPaste( self, Player, Ent, CreatedEntities )
 


### PR DESCRIPTION
Hello, I noticed some server owners complaining about lag issues towards the weight check on ACF guns. I don't really know why that was added anyways because it does a massive overheading loop, so I'm suggestion this change to let the server owners decide if they want to have that option activated or not. And since parenting is also important in some contraptions, I added another console command for it. They're:
acf_parentable [1/0]
acf_weightable [1/0]
And they're defaulted to zero. I tested the script on my Garry's Mod and it worked fine.

P.S.: Sorry for the misleading title on acf_globals.lua and acf_ammo.lua, I totally forgot about them. And also sorry for forgetting about the version variable.