### PR TITLE
FIX: Make acf_bulleteffect use SetEntity() instead of SetMagnitude()

### DIFF
--- a/lua/acf/server/sv_acfballistics.lua
+++ b/lua/acf/server/sv_acfballistics.lua
@@ -238,7 +238,7 @@ function ACF_BulletClient( Index, Bullet, Type, Hit, HitPos )
 			Effect:SetAttachment( Index )		--Bulet Index
 			Effect:SetStart( Bullet.Flight/10 )	--Bullet Direction
 			Effect:SetOrigin( Bullet.Pos )
-			Effect:SetMagnitude( Bullet["Crate"] ) --Encodes the crate the ammo originates from so clientside knows the crate from wich to pull ammo data
+			Effect:SetEntity( Entity(Bullet["Crate"]) )
 			Effect:SetScale( 0 )
 		util.Effect( "ACF_BulletEffect", Effect, true, true )
 

--- a/lua/effects/acf_bulleteffect/init.lua
+++ b/lua/effects/acf_bulleteffect/init.lua
@@ -43,7 +43,7 @@ function EFFECT:Init( data )
 	else
 		--print("Creating Bullet Effect")
 		local BulletData = {}
-		BulletData.Crate = Entity(math.Round(data:GetMagnitude()))
+		BulletData.Crate = data:GetEntity()
 		--TODO: Check if it is actually a crate
 		if not IsValid(BulletData.Crate) then
 			self:Remove() 


### PR DESCRIPTION
This is an issue that can commonly be observed on gm_carcon_ws. When debugging the entity IDs that are being by the server, aswell as what the client is receiving, significant differences can be seen.

In my test, the server was sending the entity ID `1130` - yet the client received `1022.7502441406`. With the current setup, the bullet effect attempts to compensate for this by rounding the result to `1023`, however this is still not the ammo crate that was specified by the server, thus the effect doesn't display properly.

I was unable to reproduce this behaviour on other maps, which makes this a rather specific issue. I can however confirm that in all tested instances, SetEntity() fixes the issue altogether, and effects have shown up properly since.

Thanks in advance!