### PR TITLE
fixed acfMaxPower() and acfMaxTorque() e2 functions

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/acffunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/acffunctions.lua
@@ -258,19 +258,29 @@ end
 -- Returns the torque in N/m of an ACF engine
 e2function number entity:acfMaxTorque()
 	if not isEngine(this) then return 0 end
-	return this.PeakTorque or 0
+
+	local powerMul = 1
+
+	if table.Count(this.FuelLink) != 0 or this.RequiresFuel then powerMul = ACF.TorqueBoost end
+
+	return this.PeakTorque*powerMul or 0
 end
 
 -- Returns the power in kW of an ACF engine
 e2function number entity:acfMaxPower()
 	if not isEngine(this) then return 0 end
 	local peakpower
+
+	local powerMul = 1
+
+	if table.Count(this.FuelLink) != 0 or this.RequiresFuel then powerMul = ACF.TorqueBoost end
+
 	if this.iselec then
 		peakpower = math.floor(this.PeakTorque * this.LimitRPM / (4*9548.8))
 	else
 		peakpower = math.floor(this.PeakTorque * this.PeakMaxRPM / 9548.8)
 	end
-	return peakpower or 0
+	return peakpower*powerMul or 0
 end
 
 -- Returns the idle rpm of an ACF engine

--- a/lua/entities/gmod_wire_expression2/core/custom/acffunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/acffunctions.lua
@@ -43,6 +43,22 @@ local function restrictInfo(ply, ent)
 	return false
 end
 
+local function getMaxTorque(ent)
+	if not isEngine(ent) then return 0 end
+	return ent.PeakTorque or 0
+end
+
+local function getMaxPower(ent)
+	if not isEngine(ent) then return 0 end
+	local peakpower
+	if ent.iselec then
+		peakpower = math.floor(ent.PeakTorque * ent.LimitRPM / (38195.2)) --(4*9548.8)
+	else
+		peakpower = math.floor(ent.PeakTorque * ent.PeakMaxRPM / 9548.8)
+	end
+	return peakpower or 0
+end
+
 local function isLinkableACFEnt(ent)
 
 	if not validPhysics(ent) then return false end
@@ -257,31 +273,27 @@ end
 
 -- Returns the torque in N/m of an ACF engine
 e2function number entity:acfMaxTorque()
-	if not isEngine(this) then return 0 end
-
-	local powerMul = 1
-
-	if table.Count(this.FuelLink) != 0 or this.RequiresFuel then powerMul = ACF.TorqueBoost end
-
-	return this.PeakTorque*powerMul or 0
+	return getMaxTorque(this)
 end
 
 -- Returns the power in kW of an ACF engine
 e2function number entity:acfMaxPower()
-	if not isEngine(this) then return 0 end
-	local peakpower
-
-	local powerMul = 1
-
-	if table.Count(this.FuelLink) != 0 or this.RequiresFuel then powerMul = ACF.TorqueBoost end
-
-	if this.iselec then
-		peakpower = math.floor(this.PeakTorque * this.LimitRPM / (4*9548.8))
-	else
-		peakpower = math.floor(this.PeakTorque * this.PeakMaxRPM / 9548.8)
-	end
-	return peakpower*powerMul or 0
+	return getMaxPower(this)
 end
+
+-- Same as the two above just with fuel duhhh//
+
+e2function number entity:acfMaxTorqueWithFuel()
+	return getMaxTorque(this)*ACF.TorqueBoost or 0
+end
+
+-- Detailed explanation of this function
+
+e2function number entity:acfMaxPowerWithFuel()
+	return getMaxPower(this)*ACF.TorqueBoost or 0
+end
+
+--//
 
 -- Returns the idle rpm of an ACF engine
 e2function number entity:acfIdleRPM()

--- a/lua/entities/gmod_wire_expression2/core/custom/cl_acfdescriptions.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cl_acfdescriptions.lua
@@ -19,6 +19,8 @@ E2Helper.Descriptions["acfDragDiv"] = "Returns current ACF drag divisor"
 --engine
 E2Helper.Descriptions["acfMaxTorque"] = "Returns the maximum torque (in N/m) of an ACF engine."
 E2Helper.Descriptions["acfMaxPower"] = "Returns the maximum power (in kW) of an ACF engine."
+E2Helper.Descriptions["acfMaxTorqueWithFuel"] = "Returns the maximum torque (in N/m) of an ACF engine with fuel linked."
+E2Helper.Descriptions["acfMaxPowerWithFuel"] = "Returns the maximum power (in kW) of an ACF engine with fuel linked."
 E2Helper.Descriptions["acfIdleRPM"] = "Returns the idle RPM of an ACF engine."
 E2Helper.Descriptions["acfPowerbandMin"] = "Returns the powerband minimum of an ACF engine."
 E2Helper.Descriptions["acfPowerbandMax"] = "Returns the powerband maximum of an ACF engine."


### PR DESCRIPTION
acfMaxPower() and acfMaxTorque() now take linked fueltanks and "fuel required" properties into account and return values accordingly

(I'm not sure if the original code was intended to be the way it is)