### PR TITLE
Fixed folder capitalization for Linux-based servers, and rare bug with default damage permissions

### DIFF
--- a/lua/acf/server/sv_acfpermission.lua
+++ b/lua/acf/server/sv_acfpermission.lua
@@ -461,13 +461,13 @@ function this.RegisterMode(mode, name, desc, default, think, defaultaction)
 			this.DefaultPermission = name
 		end
 	end
-		
+	
+	--Old method - can break on rare occasions!
 	--if LoadMapDPM() == name or default then 
 	--	print("ACF: Setting permission mode to: "..name)
 	--	this.DamagePermission = this.Modes[name]
 	--	this.DefaultPermission = name
 	--end
-	
 end
 
 

--- a/lua/acf/server/sv_acfpermission.lua
+++ b/lua/acf/server/sv_acfpermission.lua
@@ -15,8 +15,8 @@ this.ModeDescs = {}
 this.ModeThinks = {}
 
 //TODO: convar this
-local mapSZDir = "ACF/safezones/"
-local mapDPMDir = "ACF/permissions/"
+local mapSZDir = "acf/safezones/"
+local mapDPMDir = "acf/permissions/"
 file.CreateDir(mapDPMDir)
 
 
@@ -444,12 +444,29 @@ function this.RegisterMode(mode, name, desc, default, think, defaultaction)
 	this.DefaultCanDamage = defaultaction or false
 	print("ACF: Registered damage permission mode \"" .. name .. "\"!")
 	
+	local DPM = LoadMapDPM()
 	
-	if LoadMapDPM() == name or default then 
-		print("ACF: Setting permission mode to: "..name)
-		this.DamagePermission = this.Modes[name]
-		this.DefaultPermission = name
+	if DPM ~= nil then
+		if DPM == name then
+			print("ACF: Found default permission mode: " .. DPM)
+			print("ACF: Setting permission mode to: " .. name)
+			this.DamagePermission = this.Modes[name]
+			this.DefaultPermission = name
+		end
+	else
+		if default then
+			print("ACF: Map does not have default permission set, using default")
+			print("ACF: Setting permission mode to: " .. name)
+			this.DamagePermission = this.Modes[name]
+			this.DefaultPermission = name
+		end
 	end
+		
+	--if LoadMapDPM() == name or default then 
+	--	print("ACF: Setting permission mode to: "..name)
+	--	this.DamagePermission = this.Modes[name]
+	--	this.DefaultPermission = name
+	--end
 	
 end
 


### PR DESCRIPTION
A few Linux-based servers I have had issues with damage permissions not loading properly, turns out folder capitalization was the issue. The other bug was how ACF loaded default permissions - there's a rare condition where it can load the map's default safezone and THEN loads the safezone with the "default" flag enabled - overwriting what the current map default is and forcing it to the global default.