### PR TITLE
Hotfix for Engine:acfFuelRequired()

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/acffunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/acffunctions.lua
@@ -876,7 +876,7 @@ end
 
 -- Returns 1 if the current engine requires fuel to run
 e2function number entity:acfFuelRequired()
-	if not isFuel(this) then return 0 end
+	if not isEngine(this) then return 0 end
 	if restrictInfo(self, this) then return 0 end
 	return (this.RequiresFuel and 1) or 0
 end

--- a/lua/entities/gmod_wire_expression2/core/custom/acffunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/acffunctions.lua
@@ -271,6 +271,11 @@ e2function number entity:acfIsEngine()
 	if isEngine(this) then return 1 else return 0 end
 end
 
+-- Returns 1 if an ACF engine is electric
+e2function number entity:acfIsElectric()
+	if ( this.iselec == true ) then return 1 else return 0 end
+end
+
 -- Returns the torque in N/m of an ACF engine
 e2function number entity:acfMaxTorque()
 	return getMaxTorque(this)


### PR DESCRIPTION
Hotfix for Engine:acfFuelRequired(). Should now properly return 1 if the engine requires fuel to start and run