### PR TITLE
Reload exploit fix

### DIFF
--- a/lua/entities/acf_gun.lua
+++ b/lua/entities/acf_gun.lua
@@ -417,7 +417,7 @@ end
 
 function ENT:TriggerInput( iname, value )
 	
-	if (iname == "Unload" and value > 0) then
+	if (iname == "Unload" and value > 0 and !self.Reloading) then
 		self:UnloadAmmo()
 	elseif ( iname == "Fire" and value > 0 and ACF.GunfireEnabled ) then
 		if self.NextFire < CurTime() then


### PR DESCRIPTION
Prevents instant reloads caused by the use of the unload input while reloading a magazine fed weapon