### PR TITLE
Penetration rework + HEAT fix

### DIFF
--- a/lua/acf/shared/rounds/roundap.lua
+++ b/lua/acf/shared/rounds/roundap.lua
@@ -36,7 +36,7 @@ function Round.convert( Crate, PlayerData )
 	Data.DragCoef = ((Data.FrAera/10000)/Data.ProjMass)
 	Data.LimitVel = 800										--Most efficient penetration speed in m/s
 	Data.KETransfert = 0.1									--Kinetic energy transfert to the target for movement purposes
-	Data.Ricochet = 75										--Base ricochet angle
+	Data.Ricochet = 60										--Base ricochet angle
 	Data.MuzzleVel = ACF_MuzzleVelocity( Data.PropMass, Data.ProjMass, Data.Caliber )
 	
 	Data.BoomPower = Data.PropMass

--- a/lua/acf/shared/rounds/roundaphe.lua
+++ b/lua/acf/shared/rounds/roundaphe.lua
@@ -51,7 +51,7 @@ function Round.convert( Crate, PlayerData )
 	Data.DragCoef = ((Data.FrAera/10000)/Data.ProjMass)
 	Data.LimitVel = 700										--Most efficient penetration speed in m/s
 	Data.KETransfert = 0.1									--Kinetic energy transfert to the target for movement purposes
-	Data.Ricochet = 75										--Base ricochet angle
+	Data.Ricochet = 65										--Base ricochet angle
 	
 	Data.BoomPower = Data.PropMass + Data.FillerMass
 

--- a/lua/acf/shared/rounds/roundhe.lua
+++ b/lua/acf/shared/rounds/roundhe.lua
@@ -52,6 +52,7 @@ function Round.convert( Crate, PlayerData )
 	Data.LimitVel = 100										--Most efficient penetration speed in m/s
 	Data.KETransfert = 0.1									--Kinetic energy transfert to the target for movement purposes
 	Data.Ricochet = 60										--Base ricochet angle
+	Data.DetonatorAngle = 80
 	
 	Data.BoomPower = Data.PropMass + Data.FillerMass
 

--- a/lua/acf/shared/rounds/roundsmoke.lua
+++ b/lua/acf/shared/rounds/roundsmoke.lua
@@ -62,6 +62,7 @@ function Round.convert( Crate, PlayerData )
 	Data.LimitVel = 100										--Most efficient penetration speed in m/s
 	Data.KETransfert = 0.1									--Kinetic energy transfert to the target for movement purposes
 	Data.Ricochet = 60										--Base ricochet angle
+	Data.DetonatorAngle = 80
 	
 	if PlayerData.Data7 < 0.5 then
 		PlayerData.Data7 = 0

--- a/lua/autorun/acf_globals.lua
+++ b/lua/autorun/acf_globals.lua
@@ -16,6 +16,7 @@ ACF.GroundtoRHA = 0.15		--How much mm of steel is a mm of ground worth (Real soi
 ACF.KEtoSpall = 1
 ACF.AmmoMod = 0.6		-- Ammo modifier. 1 is 1x the amount of ammo
 ACF.ArmorMod = 1
+ACF.SlopeEffectFactor = 1.1	-- Sloped armor effectiveness: armor / cos(angle)^factor
 ACF.Spalling = 0
 ACF.GunfireEnabled = true
 ACF.MeshCalcEnabled = false
@@ -30,6 +31,7 @@ ACF.HEATMVScale = 0.74	--Filler KE to HEAT slug KE conversion expotential
 ACF.HEATMulAmmo = 16.5 		--HEAT slug damage multiplier; 13.2x roughly equal to AP damage
 ACF.HEATMulFuel = 8.25		--needs less multiplier, much less health than ammo
 ACF.HEATMulEngine = 8.25	--likewise
+ACF.HEATPenLayerMul = 0.75	--HEAT base energy multiplier
 
 ACF.DragDiv = 40		--Drag fudge factor
 ACF.VelScale = 1		--Scale factor for the shell velocities in the game world
@@ -46,6 +48,8 @@ ACF.TorqueBoost = 1.25 --torque multiplier from using fuel
 ACF.FuelRate = 5  --multiplier for fuel usage, 1.0 is approx real world
 ACF.ElecRate = 1.5 --multiplier for electrics
 ACF.TankVolumeMul = 0.5 -- multiplier for fuel tank capacity, 1.0 is approx real world
+
+
 
 ACF.FuelDensity = { --kg/liter
 	Diesel = 0.832,  

--- a/lua/entities/gmod_wire_expression2/core/custom/acffunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/acffunctions.lua
@@ -713,7 +713,7 @@ end
 e2function string entity:acfRoundType() --cartridge?
 	if not isAmmo(this) then return "" end
 	if restrictInfo(self, this) then return "" end
-	return this.RoundId or ""
+	return this.RoundType or ""
 end
 
 -- Returns the type of ammo in a crate or gun


### PR DESCRIPTION
This code is working, but would I recommend someone to test it.

Change list: 
- Penetration rework:
     + Changed order of penetration checks to:
            - breach_check -> penetration_check -> ricochet_check
     + Added breach mechanics
            - Breach is penetration of armor ignoring its angle. It happens randomly, when round caliber to armor ratio is > 1.3 giving probability of 0%, ratios larger than 7x armor give 100% breach probability
     + Added penetration randomization
            - Added new variable ACF.SlopeEffectFactor (default value - 1.1). It is used to configure sloped armor effectiveness:        (armor / cos(angle)^factor)
            - Penetration value now represents 50% penetration probability. To get ~95%, penetration must be > 1.1x target armor (0.9x armor gives 5% probability)
     + Changed ricochet distribution (thegrb93)
            - Now best (base) ricochet angles are at LimitVel of round. Every 100m/s of velocity difference subtracts 1 degree from base ricochet angle
            - Some optimizations to calculation of bullet vector after ricochet
            - Changed base ricochet angles for some rounds
            - Added possibility of rounds with caliber < 20mm to ricochet at any angle (up to 5%)
            * **Ricochets from World weren't changed**
 - Fixed HEAT energy loss after penetration (was completely broken making HEAT rounds completely useless):
     + Added missing ACF.HEATPenLayerMul (default value 0.75)
     + Added HEAT, HE, SM rounds specific detonator angle (Data.DetonatorAngle)
           - When DetonatorAngle is set, center of distibution is independent of velocity and remains static
- Fixed e2 function entity:acfRoundType()