### PR TITLE
[E2] acfSetFuel for fuel ammount persistence

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/acffunctions.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/acffunctions.lua
@@ -917,6 +917,20 @@ e2function number entity:acfFuel()
 	return 0
 end
 
+-- Sets the tank fuel to the specified ammount
+e2function void entity:acfSetFuel(number ammount)
+    if not isFuel(this) then return end
+	if not isOwner(self, this) then return end
+
+	if ammount >= 0 then
+		if ammount > this.Capacity then
+			this.Fuel = this.Capacity
+		else
+			this.Fuel = ammount
+		end
+	end
+end
+
 -- Returns the amount of fuel in an ACF fuel tank or linked to engine as a percentage of capacity
 e2function number entity:acfFuelLevel()
 	if isFuel(this) then

--- a/lua/entities/gmod_wire_expression2/core/custom/cl_acfdescriptions.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cl_acfdescriptions.lua
@@ -94,6 +94,7 @@ E2Helper.Descriptions["acfEffectiveArmor"] = "Returns the effective armor of a g
 
 --fuel
 E2Helper.Descriptions["acfFuel"] = "Returns the remaining liters of fuel or kilowatt hours in an ACF fuel tank, or available to an engine."
+E2Helper.Descriptions["acfSetFuel"] = "Sets the tank fuel to the specified ammount."
 E2Helper.Descriptions["acfFuelLevel"] = "Returns the percent remaining fuel in an ACF fuel tank, or available to an engine."
 E2Helper.Descriptions["acfFuelRequired"] = "Returns 1 if an ACF engine requires fuel."
 E2Helper.Descriptions["acfRefuelDuty"] = "Sets an ACF fuel tank on refuel duty, causing it to supply other fuel tanks with fuel."


### PR DESCRIPTION
Hello guys! Great work on this addon, I use it all the time!

I'd added this function to set the ammount of fuel in fuel tanks so it can be persisted between dupes by using files or such. So when you paste a contraption, it loads the last fuel ammount and sets it to the fuel tanks linked.