### PR TITLE
Diesel Fuel won't explode on impact

### DIFF
--- a/lua/entities/acf_fueltank.lua
+++ b/lua/entities/acf_fueltank.lua
@@ -205,7 +205,7 @@ function ENT:ACF_OnDamage( Entity, Energy, FrAera, Angle, Inflictor, Bone, Type 
 	local Mul = ((Type == "HEAT" and ACF.HEATMulFuel) or 1) --Heat penetrators deal bonus damage to fuel
 	local HitRes = ACF_PropDamage( Entity, Energy, FrAera * Mul, Angle, Inflictor )	--Calling the standard damage prop function
 	
-	local NoExplode = self.FuelType == "Diesel" and not (Type == "HE" or Type == "HEAT")
+	local NoExplode = self.FuelType == "Diesel"
 	if self.Exploding or NoExplode or not self.IsExplosive then return HitRes end
 	
 	if HitRes.Kill then


### PR DESCRIPTION
Currently Diesel will still explode if hit by HE or HEAT, with this change Diesel will not explode if hit by one of these shells but will still burn up and become useless upon impact.