### PR TITLE
Add limits for large caliber and rapidfire guns

### DIFF
--- a/lua/autorun/acf_globals.lua
+++ b/lua/autorun/acf_globals.lua
@@ -105,6 +105,9 @@ end
 
 
 CreateConVar('sbox_max_acf_gun', 16)
+CreateConVar('sbox_max_acf_rapidgun', 4) --Guns like RACs, MGs, and ACs
+CreateConVar('sbox_max_acf_largegun', 4) --Guns with a caliber above 100mm
+ACF.LargeCaliber = 10 --Gun caliber in CM to be considered a large caliber gun, 10cm = 100mm
 CreateConVar('sbox_max_acf_smokelauncher', 10)
 CreateConVar('sbox_max_acf_ammo', 32)
 CreateConVar('sbox_max_acf_misc', 32)

--- a/lua/entities/acf_gun.lua
+++ b/lua/entities/acf_gun.lua
@@ -160,6 +160,13 @@ function MakeACF_Gun(Owner, Pos, Angle, Id)
 	if Lookup.gunclass == "SL" then
 		if not Owner:CheckLimit("_acf_smokelauncher") then return false end
 	else
+		
+	if Lookup.gunclass == "RAC" or Lookup.gunclass == "MG" or Lookup.gunclass == "AC" then --Israpidfire?
+		if not Owner:CheckLimit("_acf_rapidgun") then return false end
+	elseif Lookup.caliber >= ACF.LargeCaliber then --IsBigGun?
+		if not Owner:CheckLimit("_acf_largegun") then return false end
+	end		
+		
 		if not Owner:CheckLimit("_acf_gun") then return false end
 	end
 	
@@ -238,6 +245,13 @@ function MakeACF_Gun(Owner, Pos, Angle, Id)
 	if Lookup.gunclass == "SL" then
 		Owner:AddCount("_acf_smokelauncher", Gun)
 	else
+		
+	if Lookup.gunclass == "RAC" or Lookup.gunclass == "MG" or Lookup.gunclass == "AC" then
+		Owner:AddCount("_acf_rapidgun", Gun)
+	elseif Lookup.caliber >= ACF.LargeCaliber then
+		Owner:AddCount("_acf_largegun", Gun)
+	end			
+		
 		Owner:AddCount("_acf_gun", Gun)
 	end
 	


### PR DESCRIPTION
Creates console limits for rapid firing guns like MGs, RACs, and ACs along with large caliber guns with a caliber above a value set in ACF Globals (Default: 100mm)