### PR TITLE
Starfall Fixes and Updated

### DIFF
--- a/lua/starfall/libs_cl/docs.lua
+++ b/lua/starfall/libs_cl/docs.lua
@@ -1,0 +1,285 @@
+-- Load Docs, nothing else
+-- Sadly we cant have it in the fancy helper but it will work in the old one and syntax highlighting
+
+table.Merge(SF.Docs, {["classes"]={[1]="Entity";["Entity"]={["class"]="class";["classForced"]=true;["description"]="\
+Entity type";["fields"]={};["methods"]={[1]="acfAmmoCount";[10]="acfClutch";[11]="acfClutchLeft";[12]="acfClutchRight";[13]="acfFLSpikeMass";[14]="acfFLSpikeRadius";[15]="acfFLSpikes";[16]="acfFinalRatio";[17]="acfFire";[18]="acfFireRate";[19]="acfFlyInertia";[2]="acfAmmoType";[20]="acfFlyMass";[21]="acfFuel";[22]="acfFuelLevel";[23]="acfFuelRequired";[24]="acfFuelUse";[25]="acfGear";[26]="acfGearRatio";[27]="acfGetActive";[28]="acfGetLinkedWheels";[29]="acfGetThrottle";[3]="acfBlastRadius";[30]="acfHitClip";[31]="acfHoldGear";[32]="acfIdleRPM";[33]="acfInGear";[34]="acfInPowerband";[35]="acfIsAmmo";[36]="acfIsDual";[37]="acfIsElectric";[38]="acfIsEngine";[39]="acfIsFuel";[4]="acfBrake";[40]="acfIsGearbox";[41]="acfIsGun";[42]="acfIsInfoRestricted";[43]="acfIsReloading";[44]="acfLinkTo";[45]="acfLinks";[46]="acfMagReloadTime";[47]="acfMagRounds";[48]="acfMagSize";[49]="acfMaxPower";[5]="acfBrakeLeft";[50]="acfMaxPowerWithFuel";[51]="acfMaxTorque";[52]="acfMaxTorqueWithFuel";[53]="acfMuzzleVel";[54]="acfName";[55]="acfNameShort";[56]="acfNumGears";[57]="acfPeakFuelUse";[58]="acfPenetration";[59]="acfPower";[6]="acfBrakeRight";[60]="acfPowerband";[61]="acfPowerbandMax";[62]="acfPowerbandMin";[63]="acfProjectileMass";[64]="acfPropArmor";[65]="acfPropArmorMax";[66]="acfPropDuctility";[67]="acfPropHealth";[68]="acfPropHealthMax";[69]="acfRPM";[7]="acfCVTRatio";[70]="acfReady";[71]="acfRedline";[72]="acfRefuelDuty";[73]="acfReload";[74]="acfReloadProgress";[75]="acfReloadTime";[76]="acfRoundType";[77]="acfRounds";[78]="acfSetActive";[79]="acfSetThrottle";[8]="acfCaliber";[80]="acfShift";[81]="acfShiftDown";[82]="acfShiftPointScale";[83]="acfShiftTime";[84]="acfShiftUp";[85]="acfSpread";[86]="acfSteerRate";[87]="acfTorque";[88]="acfTorqueOut";[89]="acfTorqueRating";[9]="acfCapacity";[90]="acfTotalAmmoCount";[91]="acfTotalRatio";[92]="acfType";[93]="acfUnlinkFrom";[94]="acfUnload";["acfAmmoCount"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the number of rounds in active ammo crates linked to an ACF weapon";["fname"]="acfAmmoCount";["name"]="ents_methods:acfAmmoCount";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the number of rounds in active ammo crates linked to an ACF weapon ";};["acfAmmoType"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the type of ammo in a crate or gun";["fname"]="acfAmmoType";["name"]="ents_methods:acfAmmoType";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the type of ammo in a crate or gun ";};["acfBlastRadius"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the blast radius of an HE, APHE, or HEAT round";["fname"]="acfBlastRadius";["name"]="ents_methods:acfBlastRadius";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the blast radius of an HE, APHE, or HEAT round ";};["acfBrake"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Sets the brakes for an ACF gearbox";["fname"]="acfBrake";["name"]="ents_methods:acfBrake";["param"]={[1]="brake";};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Sets the brakes for an ACF gearbox ";};["acfBrakeLeft"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Sets the left brakes for an ACF gearbox";["fname"]="acfBrakeLeft";["name"]="ents_methods:acfBrakeLeft";["param"]={[1]="brake";};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Sets the left brakes for an ACF gearbox ";};["acfBrakeRight"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Sets the right brakes for an ACF gearbox";["fname"]="acfBrakeRight";["name"]="ents_methods:acfBrakeRight";["param"]={[1]="brake";};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Sets the right brakes for an ACF gearbox ";};["acfCVTRatio"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Sets the gear ratio of a CVT, set to 0 to use built-in algorithm";["fname"]="acfCVTRatio";["name"]="ents_methods:acfCVTRatio";["param"]={[1]="ratio";};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Sets the gear ratio of a CVT, set to 0 to use built-in algorithm ";};["acfCaliber"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the caliber of an ammo or gun";["fname"]="acfCaliber";["name"]="ents_methods:acfCaliber";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the caliber of an ammo or gun ";};["acfCapacity"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the capacity of an acf ammo crate or fuel tank";["fname"]="acfCapacity";["name"]="ents_methods:acfCapacity";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the capacity of an acf ammo crate or fuel tank ";};["acfClutch"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Sets the clutch for an ACF gearbox";["fname"]="acfClutch";["name"]="ents_methods:acfClutch";["param"]={[1]="clutch";};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Sets the clutch for an ACF gearbox ";};["acfClutchLeft"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Sets the left clutch for an ACF gearbox";["fname"]="acfClutchLeft";["name"]="ents_methods:acfClutchLeft";["param"]={[1]="clutch";};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Sets the left clutch for an ACF gearbox ";};["acfClutchRight"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Sets the right clutch for an ACF gearbox";["fname"]="acfClutchRight";["name"]="ents_methods:acfClutchRight";["param"]={[1]="clutch";};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Sets the right clutch for an ACF gearbox ";};["acfFLSpikeMass"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the mass of a single spike in a FL round in a crate or gun";["fname"]="acfFLSpikeMass";["name"]="ents_methods:acfFLSpikeMass";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the mass of a single spike in a FL round in a crate or gun ";};["acfFLSpikeRadius"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the radius of the spikes in a flechette round in mm";["fname"]="acfFLSpikeRadius";["name"]="ents_methods:acfFLSpikeRadius";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the radius of the spikes in a flechette round in mm ";};["acfFLSpikes"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the number of projectiles in a flechette round";["fname"]="acfFLSpikes";["name"]="ents_methods:acfFLSpikes";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the number of projectiles in a flechette round ";};["acfFinalRatio"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the final ratio for an ACF gearbox";["fname"]="acfFinalRatio";["name"]="ents_methods:acfFinalRatio";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the final ratio for an ACF gearbox ";};["acfFire"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Sets the firing state of an ACF weapon";["fname"]="acfFire";["name"]="ents_methods:acfFire";["param"]={[1]="fire";};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Sets the firing state of an ACF weapon ";};["acfFireRate"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the rate of fire of an acf gun";["fname"]="acfFireRate";["name"]="ents_methods:acfFireRate";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the rate of fire of an acf gun ";};["acfFlyInertia"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the inertia of an ACF engine's flywheel";["fname"]="acfFlyInertia";["name"]="ents_methods:acfFlyInertia";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the inertia of an ACF engine's flywheel ";};["acfFlyMass"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the mass of an ACF engine's flywheel";["fname"]="acfFlyMass";["name"]="ents_methods:acfFlyMass";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the mass of an ACF engine's flywheel ";};["acfFuel"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the remaining liters or kilowatt hours of fuel in an ACF fuel tank or engine";["fname"]="acfFuel";["name"]="ents_methods:acfFuel";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the remaining liters or kilowatt hours of fuel in an ACF fuel tank or engine ";};["acfFuelLevel"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the amount of fuel in an ACF fuel tank or linked to engine as a percentage of capacity";["fname"]="acfFuelLevel";["name"]="ents_methods:acfFuelLevel";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the amount of fuel in an ACF fuel tank or linked to engine as a percentage of capacity ";};["acfFuelRequired"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns true if the current engine requires fuel to run";["fname"]="acfFuelRequired";["name"]="ents_methods:acfFuelRequired";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns true if the current engine requires fuel to run ";};["acfFuelUse"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the current fuel consumption in liters per minute or kilowatts of an engine";["fname"]="acfFuelUse";["name"]="ents_methods:acfFuelUse";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the current fuel consumption in liters per minute or kilowatts of an engine ";};["acfGear"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the current gear for an ACF gearbox";["fname"]="acfGear";["name"]="ents_methods:acfGear";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the current gear for an ACF gearbox ";};["acfGearRatio"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the ratio for a specified gear of an ACF gearbox";["fname"]="acfGearRatio";["name"]="ents_methods:acfGearRatio";["param"]={[1]="gear";};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the ratio for a specified gear of an ACF gearbox ";};["acfGetActive"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns true if the acf engine, fuel tank, or ammo crate is active";["fname"]="acfGetActive";["name"]="ents_methods:acfGetActive";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns true if the acf engine, fuel tank, or ammo crate is active ";};["acfGetLinkedWheels"]={["class"]="function";["classlib"]="Entity";["description"]="\
+returns any wheels linked to this engine/gearbox or child gearboxes";["fname"]="acfGetLinkedWheels";["name"]="ents_methods:acfGetLinkedWheels";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+returns any wheels linked to this engine/gearbox or child gearboxes ";};["acfGetThrottle"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the throttle value";["fname"]="acfGetThrottle";["name"]="ents_methods:acfGetThrottle";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the throttle value ";};["acfHitClip"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns true if hitpos is on a clipped part of prop";["fname"]="acfHitClip";["name"]="ents_methods:acfHitClip";["param"]={[1]="hitpos";};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns true if hitpos is on a clipped part of prop ";};["acfHoldGear"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Applies gear hold for an automatic ACF gearbox";["fname"]="acfHoldGear";["name"]="ents_methods:acfHoldGear";["param"]={[1]="hold";};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Applies gear hold for an automatic ACF gearbox ";};["acfIdleRPM"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the idle rpm of an ACF engine";["fname"]="acfIdleRPM";["name"]="ents_methods:acfIdleRPM";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the idle rpm of an ACF engine ";};["acfInGear"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns true if an ACF gearbox is in gear";["fname"]="acfInGear";["name"]="ents_methods:acfInGear";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns true if an ACF gearbox is in gear ";};["acfInPowerband"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns true if the RPM of an ACF engine is inside the powerband";["fname"]="acfInPowerband";["name"]="ents_methods:acfInPowerband";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns true if the RPM of an ACF engine is inside the powerband ";};["acfIsAmmo"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns true if the entity is an ACF ammo crate";["fname"]="acfIsAmmo";["name"]="ents_methods:acfIsAmmo";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns true if the entity is an ACF ammo crate ";};["acfIsDual"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns whether an ACF gearbox is dual clutch";["fname"]="acfIsDual";["name"]="ents_methods:acfIsDual";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns whether an ACF gearbox is dual clutch ";};["acfIsElectric"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns true if an ACF engine is electric";["fname"]="acfIsElectric";["name"]="ents_methods:acfIsElectric";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns true if an ACF engine is electric ";};["acfIsEngine"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns true if the entity is an ACF engine";["fname"]="acfIsEngine";["name"]="ents_methods:acfIsEngine";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns true if the entity is an ACF engine ";};["acfIsFuel"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns true if the entity is an ACF fuel tank";["fname"]="acfIsFuel";["name"]="ents_methods:acfIsFuel";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns true if the entity is an ACF fuel tank ";};["acfIsGearbox"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns true if the entity is an ACF gearbox";["fname"]="acfIsGearbox";["name"]="ents_methods:acfIsGearbox";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns true if the entity is an ACF gearbox ";};["acfIsGun"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns true if the entity is an ACF gun";["fname"]="acfIsGun";["name"]="ents_methods:acfIsGun";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns true if the entity is an ACF gun ";};["acfIsInfoRestricted"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns true if this entity contains sensitive info and is not accessable to us";["fname"]="acfIsInfoRestricted";["name"]="ents_methods:acfIsInfoRestricted";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns true if this entity contains sensitive info and is not accessable to us ";};["acfIsReloading"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns true if an ACF gun is reloading";["fname"]="acfIsReloading";["name"]="ents_methods:acfIsReloading";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns true if an ACF gun is reloading ";};["acfLinkTo"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Perform ACF links";["fname"]="acfLinkTo";["name"]="ents_methods:acfLinkTo";["param"]={[1]="target";[2]="notify";};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Perform ACF links ";};["acfLinks"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the ACF links associated with the entity";["fname"]="acfLinks";["name"]="ents_methods:acfLinks";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the ACF links associated with the entity ";};["acfMagReloadTime"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns time it takes for an ACF weapon to reload magazine";["fname"]="acfMagReloadTime";["name"]="ents_methods:acfMagReloadTime";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns time it takes for an ACF weapon to reload magazine ";};["acfMagRounds"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the number of rounds left in a magazine for an ACF gun";["fname"]="acfMagRounds";["name"]="ents_methods:acfMagRounds";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the number of rounds left in a magazine for an ACF gun ";};["acfMagSize"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the magazine size for an ACF gun";["fname"]="acfMagSize";["name"]="ents_methods:acfMagSize";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the magazine size for an ACF gun ";};["acfMaxPower"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the power in kW of an ACF engine";["fname"]="acfMaxPower";["name"]="ents_methods:acfMaxPower";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the power in kW of an ACF engine ";};["acfMaxPowerWithFuel"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the power in kW of an ACF engine with fuel";["fname"]="acfMaxPowerWithFuel";["name"]="ents_methods:acfMaxPowerWithFuel";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the power in kW of an ACF engine with fuel ";};["acfMaxTorque"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the torque in N/m of an ACF engine";["fname"]="acfMaxTorque";["name"]="ents_methods:acfMaxTorque";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the torque in N/m of an ACF engine ";};["acfMaxTorqueWithFuel"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the torque in N/m of an ACF engine with fuel";["fname"]="acfMaxTorqueWithFuel";["name"]="ents_methods:acfMaxTorqueWithFuel";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the torque in N/m of an ACF engine with fuel ";};["acfMuzzleVel"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the muzzle velocity of the ammo in a crate or gun";["fname"]="acfMuzzleVel";["name"]="ents_methods:acfMuzzleVel";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the muzzle velocity of the ammo in a crate or gun ";};["acfName"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the full name of an ACF entity";["fname"]="acfName";["name"]="ents_methods:acfName";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the full name of an ACF entity ";};["acfNameShort"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the short name of an ACF entity";["fname"]="acfNameShort";["name"]="ents_methods:acfNameShort";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the short name of an ACF entity ";};["acfNumGears"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the number of gears for an ACF gearbox";["fname"]="acfNumGears";["name"]="ents_methods:acfNumGears";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the number of gears for an ACF gearbox ";};["acfPeakFuelUse"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the peak fuel consumption in liters per minute or kilowatts of an engine at powerband max, for the current fuel type the engine is using";["fname"]="acfPeakFuelUse";["name"]="ents_methods:acfPeakFuelUse";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the peak fuel consumption in liters per minute or kilowatts of an engine at powerband max, for the current fuel type the engine is using ";};["acfPenetration"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the penetration of an AP, APHE, or HEAT round";["fname"]="acfPenetration";["name"]="ents_methods:acfPenetration";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the penetration of an AP, APHE, or HEAT round ";};["acfPower"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the current power of an ACF engine";["fname"]="acfPower";["name"]="ents_methods:acfPower";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the current power of an ACF engine ";};["acfPowerband"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the powerband min and max of an ACF Engine";["fname"]="acfPowerband";["name"]="ents_methods:acfPowerband";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the powerband min and max of an ACF Engine ";};["acfPowerbandMax"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the powerband max of an ACF engine";["fname"]="acfPowerbandMax";["name"]="ents_methods:acfPowerbandMax";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the powerband max of an ACF engine ";};["acfPowerbandMin"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the powerband min of an ACF engine";["fname"]="acfPowerbandMin";["name"]="ents_methods:acfPowerbandMin";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the powerband min of an ACF engine ";};["acfProjectileMass"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the mass of the projectile in a crate or gun";["fname"]="acfProjectileMass";["name"]="ents_methods:acfProjectileMass";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the mass of the projectile in a crate or gun ";};["acfPropArmor"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the current armor of an entity";["fname"]="acfPropArmor";["name"]="ents_methods:acfPropArmor";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the current armor of an entity ";};["acfPropArmorMax"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the max armor of an entity";["fname"]="acfPropArmorMax";["name"]="ents_methods:acfPropArmorMax";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the max armor of an entity ";};["acfPropDuctility"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the ductility of an entity";["fname"]="acfPropDuctility";["name"]="ents_methods:acfPropDuctility";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the ductility of an entity ";};["acfPropHealth"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the current health of an entity";["fname"]="acfPropHealth";["name"]="ents_methods:acfPropHealth";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the current health of an entity ";};["acfPropHealthMax"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the max health of an entity";["fname"]="acfPropHealthMax";["name"]="ents_methods:acfPropHealthMax";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the max health of an entity ";};["acfRPM"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the current rpm of an ACF engine";["fname"]="acfRPM";["name"]="ents_methods:acfRPM";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the current rpm of an ACF engine ";};["acfReady"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns true if the ACF gun is ready to fire";["fname"]="acfReady";["name"]="ents_methods:acfReady";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns true if the ACF gun is ready to fire ";};["acfRedline"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the redline rpm of an ACF engine";["fname"]="acfRedline";["name"]="ents_methods:acfRedline";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the redline rpm of an ACF engine ";};["acfRefuelDuty"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Sets the ACF fuel tank refuel duty status, which supplies fuel to other fuel tanks";["fname"]="acfRefuelDuty";["name"]="ents_methods:acfRefuelDuty";["param"]={[1]="on";};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Sets the ACF fuel tank refuel duty status, which supplies fuel to other fuel tanks ";};["acfReload"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Causes an ACF weapon to reload";["fname"]="acfReload";["name"]="ents_methods:acfReload";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Causes an ACF weapon to reload ";};["acfReloadProgress"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns number between 0 and 1 which represents reloading progress of an ACF weapon. Useful for progress bars";["fname"]="acfReloadProgress";["name"]="ents_methods:acfReloadProgress";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns number between 0 and 1 which represents reloading progress of an ACF weapon.";};["acfReloadTime"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns time to next shot of an ACF weapon";["fname"]="acfReloadTime";["name"]="ents_methods:acfReloadTime";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns time to next shot of an ACF weapon ";};["acfRoundType"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the type of weapon the ammo in an ACF ammo crate loads into";["fname"]="acfRoundType";["name"]="ents_methods:acfRoundType";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the type of weapon the ammo in an ACF ammo crate loads into ";};["acfRounds"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the rounds left in an acf ammo crate";["fname"]="acfRounds";["name"]="ents_methods:acfRounds";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the rounds left in an acf ammo crate ";};["acfSetActive"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Turns an ACF engine, ammo crate, or fuel tank on or off";["fname"]="acfSetActive";["name"]="ents_methods:acfSetActive";["param"]={[1]="on";};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Turns an ACF engine, ammo crate, or fuel tank on or off ";};["acfSetThrottle"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Sets the throttle value for an ACF engine";["fname"]="acfSetThrottle";["name"]="ents_methods:acfSetThrottle";["param"]={[1]="throttle";};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Sets the throttle value for an ACF engine ";};["acfShift"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Sets the current gear for an ACF gearbox";["fname"]="acfShift";["name"]="ents_methods:acfShift";["param"]={[1]="gear";};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Sets the current gear for an ACF gearbox ";};["acfShiftDown"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Cause an ACF gearbox to shift down";["fname"]="acfShiftDown";["name"]="ents_methods:acfShiftDown";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Cause an ACF gearbox to shift down ";};["acfShiftPointScale"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Sets the shift point scaling for an automatic ACF gearbox";["fname"]="acfShiftPointScale";["name"]="ents_methods:acfShiftPointScale";["param"]={[1]="scale";};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Sets the shift point scaling for an automatic ACF gearbox ";};["acfShiftTime"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the time in ms an ACF gearbox takes to change gears";["fname"]="acfShiftTime";["name"]="ents_methods:acfShiftTime";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the time in ms an ACF gearbox takes to change gears ";};["acfShiftUp"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Cause an ACF gearbox to shift up";["fname"]="acfShiftUp";["name"]="ents_methods:acfShiftUp";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Cause an ACF gearbox to shift up ";};["acfSpread"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the spread for an ACF gun or flechette ammo";["fname"]="acfSpread";["name"]="ents_methods:acfSpread";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the spread for an ACF gun or flechette ammo ";};["acfSteerRate"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Sets the steer ratio for an ACF gearbox";["fname"]="acfSteerRate";["name"]="ents_methods:acfSteerRate";["param"]={[1]="rate";};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Sets the steer ratio for an ACF gearbox ";};["acfTorque"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the current torque of an ACF engine";["fname"]="acfTorque";["name"]="ents_methods:acfTorque";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the current torque of an ACF engine ";};["acfTorqueOut"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the current torque output for an ACF gearbox";["fname"]="acfTorqueOut";["name"]="ents_methods:acfTorqueOut";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the current torque output for an ACF gearbox ";};["acfTorqueRating"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the max torque for an ACF gearbox";["fname"]="acfTorqueRating";["name"]="ents_methods:acfTorqueRating";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the max torque for an ACF gearbox ";};["acfTotalAmmoCount"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the number of rounds in all ammo crates linked to an ACF weapon";["fname"]="acfTotalAmmoCount";["name"]="ents_methods:acfTotalAmmoCount";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the number of rounds in all ammo crates linked to an ACF weapon ";};["acfTotalRatio"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the total ratio (current gear * final) for an ACF gearbox";["fname"]="acfTotalRatio";["name"]="ents_methods:acfTotalRatio";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the total ratio (current gear * final) for an ACF gearbox ";};["acfType"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Returns the type of ACF entity";["fname"]="acfType";["name"]="ents_methods:acfType";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Returns the type of ACF entity ";};["acfUnlinkFrom"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Perform ACF unlinks";["fname"]="acfUnlinkFrom";["name"]="ents_methods:acfUnlinkFrom";["param"]={[1]="target";[2]="notify";};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Perform ACF unlinks ";};["acfUnload"]={["class"]="function";["classlib"]="Entity";["description"]="\
+Causes an ACF weapon to unload";["fname"]="acfUnload";["name"]="ents_methods:acfUnload";["param"]={};["private"]=false;["realm"]="sv";["server"]=true;["summary"]="\
+Causes an ACF weapon to unload ";};};["name"]="Entity";["param"]={};["summary"]="\
+Entity type ";["typtbl"]="ents_methods";};};["directives"]={};["hooks"]={};["libraries"]={[1]="acf";["acf"]={["class"]="library";["description"]="\
+ \
+ACF Library";["fields"]={};["functions"]={[1]="createAmmo";[10]="getAllFuelTanks";[11]="getAllGearboxes";[12]="getAllGuns";[13]="getAllMobility";[14]="getAmmoSpecs";[15]="getFuelTankSpecs";[16]="getGunSpecs";[17]="getMobilitySpecs";[18]="infoRestricted";[2]="createFuelTank";[3]="createGun";[4]="createMobility";[5]="dragDivisor";[6]="effectiveArmor";[7]="getAllAmmo";[8]="getAllAmmoBoxes";[9]="getAllEngines";["createAmmo"]={["class"]="function";["description"]="\
+Creates a ammo box given the id";["fname"]="createAmmo";["library"]="acf";["name"]="acf_library.createAmmo";["param"]={[1]="pos";[2]="ang";[3]="id";[4]="gun_id";[5]="ammo_id";[6]="frozen";[7]="ammo_data";["ammo_data"]="the ammo data";["ammo_id"]="id of the ammo";["ang"]="Angle of created ammo box";["frozen"]="True to spawn frozen";["gun_id"]="id of the gun";["id"]="id of the ammo box to create";["pos"]="Position of created ammo box";};["private"]=false;["realm"]="sv";["ret"]="The created ammo box";["server"]=true;["summary"]="\
+Creates a ammo box given the id ";["usage"]="\
+If ammo_data isn't provided default values will be used (same as in the ACF menu) \
+Possible values for ammo_data corresponding to ammo_id: \
+ \
+AP: \
+- propellantLength (number) \
+- projectileLength (number) \
+- tracer (bool) \
+ \
+APHE: \
+- propellantLength (number) \
+- projectileLength (number) \
+- heFillerVolume (number) \
+- tracer (bool) \
+ \
+FL: \
+- propellantLength (number) \
+- projectileLength (number) \
+- flechettes (number) \
+- flechettesSpread (number) \
+- tracer (bool) \
+ \
+HE: \
+- propellantLength (number) \
+- projectileLength (number) \
+- heFillerVolume (number) \
+- tracer (bool) \
+ \
+HEAT: \
+- propellantLength (number) \
+- projectileLength (number) \
+- heFillerVolume (number) \
+- crushConeAngle (number) \
+- tracer (bool) \
+ \
+HP: \
+- propellantLength (number) \
+- projectileLength (number) \
+- heFillerVolume (number) \
+- hollowPointCavityVolume (number) \
+- tracer (bool) \
+ \
+SM: \
+- propellantLength (number) \
+- projectileLength (number) \
+- smokeFillerVolume (number) \
+- wpFillerVolume (number) \
+- fuseTime (number) \
+- tracer (bool) \
+ \
+Refil: \
+";};["createFuelTank"]={["class"]="function";["description"]="\
+Creates a fuel tank given the id";["fname"]="createFuelTank";["library"]="acf";["name"]="acf_library.createFuelTank";["param"]={[1]="pos";[2]="ang";[3]="id";[4]="fueltype";[5]="frozen";["ang"]="Angle of created fuel tank";["frozen"]="True to spawn frozen";["fueltype"]="The type of fuel to use (Diesel, Electric, Petrol)";["id"]="id of the fuel tank to create";["pos"]="Position of created fuel tank";};["private"]=false;["realm"]="sv";["ret"]="The created fuel tank";["server"]=true;["summary"]="\
+Creates a fuel tank given the id ";};["createGun"]={["class"]="function";["description"]="\
+Creates a fun given the id or name";["fname"]="createGun";["library"]="acf";["name"]="acf_library.createGun";["param"]={[1]="pos";[2]="ang";[3]="id";[4]="frozen";["ang"]="Angle of created gun";["frozen"]="True to spawn frozen";["id"]="id or name of the gun to create";["pos"]="Position of created gun";};["private"]=false;["realm"]="sv";["ret"]="The created gun";["server"]=true;["summary"]="\
+Creates a fun given the id or name ";};["createMobility"]={["class"]="function";["description"]="\
+Creates a engine or gearbox given the id or name";["fname"]="createMobility";["library"]="acf";["name"]="acf_library.createMobility";["param"]={[1]="pos";[2]="ang";[3]="id";[4]="frozen";[5]="gear_ratio";["ang"]="Angle of created engine or gearbox";["frozen"]="True to spawn frozen";["gear_ratio"]="A table containing the gear ratios, only applied if the mobility is a gearbox. -1 is final drive";["id"]="id or name of the engine or gearbox to create";["pos"]="Position of created engine or gearbox";};["private"]=false;["realm"]="sv";["ret"]="The created engine or gearbox";["server"]=true;["summary"]="\
+Creates a engine or gearbox given the id or name ";};["dragDivisor"]={["class"]="function";["description"]="\
+Returns current ACF drag divisor";["fname"]="dragDivisor";["library"]="acf";["name"]="acf_library.dragDivisor";["param"]={};["private"]=false;["realm"]="sv";["ret"]="The current drag divisor";["server"]=true;["summary"]="\
+Returns current ACF drag divisor ";};["effectiveArmor"]={["class"]="function";["description"]="\
+Returns the effective armor given an armor value and hit angle";["fname"]="effectiveArmor";["library"]="acf";["name"]="acf_library.effectiveArmor";["param"]={[1]="armor";[2]="angle";};["private"]=false;["realm"]="sv";["ret"]="The effective armor";["server"]=true;["summary"]="\
+Returns the effective armor given an armor value and hit angle ";};["getAllAmmo"]={["class"]="function";["description"]="\
+Returns a list of all ammo types";["fname"]="getAllAmmo";["library"]="acf";["name"]="acf_library.getAllAmmo";["param"]={};["private"]=false;["realm"]="sv";["ret"]="The ammo list";["server"]=true;["summary"]="\
+Returns a list of all ammo types ";};["getAllAmmoBoxes"]={["class"]="function";["description"]="\
+Returns a list of all ammo boxes";["fname"]="getAllAmmoBoxes";["library"]="acf";["name"]="acf_library.getAllAmmoBoxes";["param"]={};["private"]=false;["realm"]="sv";["ret"]="The ammo box list";["server"]=true;["summary"]="\
+Returns a list of all ammo boxes ";};["getAllEngines"]={["class"]="function";["description"]="\
+Returns a list of all engines";["fname"]="getAllEngines";["library"]="acf";["name"]="acf_library.getAllEngines";["param"]={};["private"]=false;["realm"]="sv";["ret"]="The engine list";["server"]=true;["summary"]="\
+Returns a list of all engines ";};["getAllFuelTanks"]={["class"]="function";["description"]="\
+Returns a list of all fuel tanks";["fname"]="getAllFuelTanks";["library"]="acf";["name"]="acf_library.getAllFuelTanks";["param"]={};["private"]=false;["realm"]="sv";["ret"]="The fuel tank list";["server"]=true;["summary"]="\
+Returns a list of all fuel tanks ";};["getAllGearboxes"]={["class"]="function";["description"]="\
+Returns a list of all gearboxes";["fname"]="getAllGearboxes";["library"]="acf";["name"]="acf_library.getAllGearboxes";["param"]={};["private"]=false;["realm"]="sv";["ret"]="The gearbox list";["server"]=true;["summary"]="\
+Returns a list of all gearboxes ";};["getAllGuns"]={["class"]="function";["description"]="\
+Returns a list of all guns";["fname"]="getAllGuns";["library"]="acf";["name"]="acf_library.getAllGuns";["param"]={};["private"]=false;["realm"]="sv";["ret"]="The guns list";["server"]=true;["summary"]="\
+Returns a list of all guns ";};["getAllMobility"]={["class"]="function";["description"]="\
+Returns a list of all mobility components";["fname"]="getAllMobility";["library"]="acf";["name"]="acf_library.getAllMobility";["param"]={};["private"]=false;["realm"]="sv";["ret"]="The mobility component list";["server"]=true;["summary"]="\
+Returns a list of all mobility components ";};["getAmmoSpecs"]={["class"]="function";["description"]="\
+Returns the specs of the ammo";["fname"]="getAmmoSpecs";["library"]="acf";["name"]="acf_library.getAmmoSpecs";["param"]={[1]="id";["id"]="id of the ammo";};["private"]=false;["realm"]="sv";["ret"]="The specs table";["server"]=true;["summary"]="\
+Returns the specs of the ammo ";};["getFuelTankSpecs"]={["class"]="function";["description"]="\
+Returns the specs of the fuel tank";["fname"]="getFuelTankSpecs";["library"]="acf";["name"]="acf_library.getFuelTankSpecs";["param"]={[1]="id";["id"]="id of the engine or gearbox";};["private"]=false;["realm"]="sv";["ret"]="The specs table";["server"]=true;["summary"]="\
+Returns the specs of the fuel tank ";};["getGunSpecs"]={["class"]="function";["description"]="\
+Returns the specs of gun";["fname"]="getGunSpecs";["library"]="acf";["name"]="acf_library.getGunSpecs";["param"]={[1]="id";["id"]="id or name of the gun";};["private"]=false;["realm"]="sv";["ret"]="The specs table";["server"]=true;["summary"]="\
+Returns the specs of gun ";};["getMobilitySpecs"]={["class"]="function";["description"]="\
+Returns the specs of the engine or gearbox";["fname"]="getMobilitySpecs";["library"]="acf";["name"]="acf_library.getMobilitySpecs";["param"]={[1]="id";["id"]="id or name of the engine or gearbox";};["private"]=false;["realm"]="sv";["ret"]="The specs table";["server"]=true;["summary"]="\
+Returns the specs of the engine or gearbox ";};["infoRestricted"]={["class"]="function";["description"]="\
+Returns true if functions returning sensitive info are restricted to owned props";["fname"]="infoRestricted";["library"]="acf";["name"]="acf_library.infoRestricted";["param"]={};["private"]=false;["realm"]="sv";["ret"]="True if restriced, False if not";["server"]=true;["summary"]="\
+Returns true if functions returning sensitive info are restricted to owned props ";};};["libtbl"]="acf_library";["name"]="acf";["summary"]="\
+ \
+ACF Library ";["tables"]={};};};})

--- a/lua/starfall/libs_sv/acffunctions.lua
+++ b/lua/starfall/libs_sv/acffunctions.lua
@@ -604,6 +604,7 @@ ammo_properties.Refill.create_data = {}
 -- @param pos Position of created ammo box
 -- @param ang Angle of created ammo box
 -- @param id id of the ammo box to create
+-- @param gun_id id of the gun
 -- @param ammo_id id of the ammo
 -- @param frozen True to spawn frozen
 -- @param ammo_data the ammo data
@@ -660,6 +661,7 @@ ammo_properties.Refill.create_data = {}
 -- \- tracer (bool)
 -- 
 -- Refil:
+-- 
 function acf_library.createAmmo(pos, ang, id, gun_id, ammo_id, frozen, ammo_data)
 	checkpermission(SF.instance, nil, "acf.createAmmo")
 	
@@ -830,7 +832,8 @@ SF.AddHook("postload", function()
 		return GetConVar( "sbox_acf_restrictinfo" ):GetInt() ~= 0
 	end]]
 
-	-- Returns true if this entity contains sensitive info and is not accessable to us
+	--- Returns true if this entity contains sensitive info and is not accessable to us
+	-- @server
 	function ents_methods:acfIsInfoRestricted ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -840,7 +843,8 @@ SF.AddHook("postload", function()
 		return restrictInfo( this )
 	end
 
-	-- Returns the short name of an ACF entity
+	--- Returns the short name of an ACF entity
+	-- @server
 	function ents_methods:acfNameShort ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -856,7 +860,8 @@ SF.AddHook("postload", function()
 		return ""
 	end
 
-	-- Returns the capacity of an acf ammo crate or fuel tank
+	--- Returns the capacity of an acf ammo crate or fuel tank
+	-- @server
 	function ents_methods:acfCapacity ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -868,7 +873,8 @@ SF.AddHook("postload", function()
 		return this.Capacity or 1
 	end
 
-	-- Returns true if the acf engine, fuel tank, or ammo crate is active
+	--- Returns true if the acf engine, fuel tank, or ammo crate is active
+	-- @server
 	function ents_methods:acfGetActive ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -885,7 +891,8 @@ SF.AddHook("postload", function()
 		return false
 	end
 
-	-- Turns an ACF engine, ammo crate, or fuel tank on or off
+	--- Turns an ACF engine, ammo crate, or fuel tank on or off
+	-- @server
 	function ents_methods:acfSetActive ( on )
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -897,7 +904,8 @@ SF.AddHook("postload", function()
 		this:TriggerInput( "Active", on and 1 or 0 )    
 	end
 
-	--returns true if hitpos is on a clipped part of prop
+	--- Returns true if hitpos is on a clipped part of prop
+	-- @server
 	function ents_methods:acfHitClip( hitpos )
 		checktype( self, ents_metatable )
 		checktype( hitpos, vec_meta )
@@ -953,7 +961,8 @@ SF.AddHook("postload", function()
 		return ret
 	end
 
-	-- Returns the ACF links associated with the entity
+	--- Returns the ACF links associated with the entity
+	-- @server
 	function ents_methods:acfLinks ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -969,7 +978,8 @@ SF.AddHook("postload", function()
 		return getLinks( this, enttype )    
 	end
 
-	-- Returns the full name of an ACF entity
+	--- Returns the full name of an ACF entity
+	-- @server
 	function ents_methods:acfName ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -988,7 +998,8 @@ SF.AddHook("postload", function()
 		return List[ acftype ][ this.Id ][ "name" ] or ""
 	end
 
-	-- Returns the type of ACF entity
+	--- Returns the type of ACF entity
+	-- @server
 	function ents_methods:acfType ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1008,7 +1019,8 @@ SF.AddHook("postload", function()
 		return ""
 	end
 
-	-- Perform ACF links
+	--- Perform ACF links
+	-- @server
 	function ents_methods:acfLinkTo ( target, notify )
 		checktype( self, ents_metatable )
 		checktype( target, ents_metatable )
@@ -1033,7 +1045,8 @@ SF.AddHook("postload", function()
 		return success, msg
 	end
 
-	-- Perform ACF unlinks
+	--- Perform ACF unlinks
+	-- @server
 	function ents_methods:acfUnlinkFrom ( target, notify )
 		checktype( self, ents_metatable )
 		checktype( target, ents_metatable )
@@ -1058,7 +1071,8 @@ SF.AddHook("postload", function()
 		return success, msg
 	end
 
-	-- returns any wheels linked to this engine/gearbox or child gearboxes
+	--- returns any wheels linked to this engine/gearbox or child gearboxes
+	-- @server
 	function ents_methods:acfGetLinkedWheels ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1076,7 +1090,8 @@ SF.AddHook("postload", function()
 
 	-- [ Engine Functions ] --
 
-	-- Returns true if the entity is an ACF engine
+	--- Returns true if the entity is an ACF engine
+	-- @server
 	function ents_methods:acfIsEngine ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1086,7 +1101,8 @@ SF.AddHook("postload", function()
 		return isEngine( this )
 	end
 
-	-- Returns true if an ACF engine is electric
+	--- Returns true if an ACF engine is electric
+	-- @server
 	function ents_methods:acfIsElectric ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1096,7 +1112,8 @@ SF.AddHook("postload", function()
 		return this.iselec == true
 	end
 
-	-- Returns the torque in N/m of an ACF engine
+	--- Returns the torque in N/m of an ACF engine
+	-- @server
 	function ents_methods:acfMaxTorque ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1107,7 +1124,8 @@ SF.AddHook("postload", function()
 		return this.PeakTorque or 0
 	end
 
-	-- Returns the torque in N/m of an ACF engine with fuel
+	--- Returns the torque in N/m of an ACF engine with fuel
+	-- @server
 	function ents_methods:acfMaxTorqueWithFuel ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1130,7 +1148,8 @@ SF.AddHook("postload", function()
 		return peakpower or 0
 	end
 
-	-- Returns the power in kW of an ACF engine
+	--- Returns the power in kW of an ACF engine
+	-- @server
 	function ents_methods:acfMaxPower ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1140,7 +1159,8 @@ SF.AddHook("postload", function()
 		return isEngine( this ) and getMaxPower( this ) or 0
 	end
 
-	-- Returns the power in kW of an ACF engine with fuel
+	--- Returns the power in kW of an ACF engine with fuel
+	-- @server
 	function ents_methods:acfMaxPowerWithFuel ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1150,7 +1170,8 @@ SF.AddHook("postload", function()
 		return (isEngine( this ) and getMaxPower( this ) or 0) * (ACF.TorqueBoost or 0)
 	end
 
-	-- Returns the idle rpm of an ACF engine
+	--- Returns the idle rpm of an ACF engine
+	-- @server
 	function ents_methods:acfIdleRPM ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1161,7 +1182,8 @@ SF.AddHook("postload", function()
 		return this.IdleRPM or 0
 	end
 
-	-- Returns the powerband min and max of an ACF Engine
+	--- Returns the powerband min and max of an ACF Engine
+	-- @server
 	function ents_methods:acfPowerband ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1172,7 +1194,8 @@ SF.AddHook("postload", function()
 		return this.PeakMinRPM or 0, this.PeakMaxRPM or 0
 	end
 
-	-- Returns the powerband min of an ACF engine
+	--- Returns the powerband min of an ACF engine
+	-- @server
 	function ents_methods:acfPowerbandMin ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1183,7 +1206,8 @@ SF.AddHook("postload", function()
 		return this.PeakMinRPM or 0
 	end
 
-	-- Returns the powerband max of an ACF engine
+	--- Returns the powerband max of an ACF engine
+	-- @server
 	function ents_methods:acfPowerbandMax ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1194,7 +1218,8 @@ SF.AddHook("postload", function()
 		return this.PeakMaxRPM or 0
 	end
 
-	-- Returns the redline rpm of an ACF engine
+	--- Returns the redline rpm of an ACF engine
+	-- @server
 	function ents_methods:acfRedline ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1205,7 +1230,8 @@ SF.AddHook("postload", function()
 		return this.LimitRPM or 0
 	end
 
-	-- Returns the current rpm of an ACF engine
+	--- Returns the current rpm of an ACF engine
+	-- @server
 	function ents_methods:acfRPM ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1217,7 +1243,8 @@ SF.AddHook("postload", function()
 		return math.floor( this.FlyRPM ) or 0
 	end
 
-	-- Returns the current torque of an ACF engine
+	--- Returns the current torque of an ACF engine
+	-- @server
 	function ents_methods:acfTorque ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1229,7 +1256,8 @@ SF.AddHook("postload", function()
 		return math.floor( this.Torque or 0 )
 	end
 
-	-- Returns the inertia of an ACF engine's flywheel
+	--- Returns the inertia of an ACF engine's flywheel
+	-- @server
 	function ents_methods:acfFlyInertia ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1241,7 +1269,8 @@ SF.AddHook("postload", function()
 		return this.Inertia or 0
 	end
 
-	-- Returns the mass of an ACF engine's flywheel
+	--- Returns the mass of an ACF engine's flywheel
+	-- @server
 	function ents_methods:acfFlyMass ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1254,6 +1283,7 @@ SF.AddHook("postload", function()
 	end
 
 	--- Returns the current power of an ACF engine
+	-- @server
 	function ents_methods:acfPower ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1265,7 +1295,8 @@ SF.AddHook("postload", function()
 		return math.floor( ( this.Torque or 0 ) * ( this.FlyRPM or 0 ) / 9548.8 )
 	end
 
-	-- Returns true if the RPM of an ACF engine is inside the powerband
+	--- Returns true if the RPM of an ACF engine is inside the powerband
+	-- @server
 	function ents_methods:acfInPowerband ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1280,6 +1311,8 @@ SF.AddHook("postload", function()
 		return true
 	end
 
+	--- Returns the throttle value
+	-- @server
 	function ents_methods:acfGetThrottle ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1291,7 +1324,8 @@ SF.AddHook("postload", function()
 		return ( this.Throttle or 0 ) * 100
 	end
 
-	-- Sets the throttle value for an ACF engine
+	--- Sets the throttle value for an ACF engine
+	-- @server
 	function ents_methods:acfSetThrottle ( throttle )
 		checktype( self, ents_metatable )
 		checkluatype( throttle, TYPE_NUMBER )
@@ -1307,7 +1341,8 @@ SF.AddHook("postload", function()
 
 	-- [ Gearbox Functions ] --
 
-	-- Returns true if the entity is an ACF gearbox
+	--- Returns true if the entity is an ACF gearbox
+	-- @server
 	function ents_methods:acfIsGearbox ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1317,7 +1352,8 @@ SF.AddHook("postload", function()
 		return isGearbox( this )
 	end
 
-	-- Returns the current gear for an ACF gearbox
+	--- Returns the current gear for an ACF gearbox
+	-- @server
 	function ents_methods:acfGear ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1329,7 +1365,8 @@ SF.AddHook("postload", function()
 		return this.Gear or 0
 	end
 
-	-- Returns the number of gears for an ACF gearbox
+	--- Returns the number of gears for an ACF gearbox
+	-- @server
 	function ents_methods:acfNumGears ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1341,7 +1378,8 @@ SF.AddHook("postload", function()
 		return this.Gears or 0
 	end
 
-	-- Returns the final ratio for an ACF gearbox
+	--- Returns the final ratio for an ACF gearbox
+	-- @server
 	function ents_methods:acfFinalRatio ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1353,7 +1391,8 @@ SF.AddHook("postload", function()
 		return this.GearTable[ "Final" ] or 0
 	end
 
-	-- Returns the total ratio (current gear * final) for an ACF gearbox
+	--- Returns the total ratio (current gear * final) for an ACF gearbox
+	-- @server
 	function ents_methods:acfTotalRatio ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1365,7 +1404,8 @@ SF.AddHook("postload", function()
 		return this.GearRatio or 0
 	end
 
-	-- Returns the max torque for an ACF gearbox
+	--- Returns the max torque for an ACF gearbox
+	-- @server
 	function ents_methods:acfTorqueRating ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1376,7 +1416,8 @@ SF.AddHook("postload", function()
 		return this.MaxTorque or 0
 	end
 
-	-- Returns whether an ACF gearbox is dual clutch
+	--- Returns whether an ACF gearbox is dual clutch
+	-- @server
 	function ents_methods:acfIsDual ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1389,7 +1430,8 @@ SF.AddHook("postload", function()
 		return this.Dual
 	end
 
-	-- Returns the time in ms an ACF gearbox takes to change gears
+	--- Returns the time in ms an ACF gearbox takes to change gears
+	-- @server
 	function ents_methods:acfShiftTime ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1400,7 +1442,8 @@ SF.AddHook("postload", function()
 		return ( this.SwitchTime or 0 ) * 1000
 	end
 
-	-- Returns true if an ACF gearbox is in gear
+	--- Returns true if an ACF gearbox is in gear
+	-- @server
 	function ents_methods:acfInGear ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1413,7 +1456,8 @@ SF.AddHook("postload", function()
 		return this.InGear
 	end
 
-	-- Returns the ratio for a specified gear of an ACF gearbox
+	--- Returns the ratio for a specified gear of an ACF gearbox
+	-- @server
 	function ents_methods:acfGearRatio ( gear )
 		checktype( self, ents_metatable )
 		checkluatype( gear, TYPE_NUMBER )
@@ -1427,7 +1471,8 @@ SF.AddHook("postload", function()
 		return this.GearTable[ g ] or 0
 	end
 
-	-- Returns the current torque output for an ACF gearbox
+	--- Returns the current torque output for an ACF gearbox
+	-- @server
 	function ents_methods:acfTorqueOut ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1438,7 +1483,8 @@ SF.AddHook("postload", function()
 		return math.min( this.TotalReqTq or 0, this.MaxTorque or 0 ) / ( this.GearRatio or 1 )
 	end
 
-	-- Sets the gear ratio of a CVT, set to 0 to use built-in algorithm
+	--- Sets the gear ratio of a CVT, set to 0 to use built-in algorithm
+	-- @server
 	function ents_methods:acfCVTRatio ( ratio )
 		checktype( self, ents_metatable )
 		checkluatype( ratio, TYPE_NUMBER )
@@ -1453,7 +1499,8 @@ SF.AddHook("postload", function()
 		this.CVTRatio = math.Clamp( ratio, 0, 1 )
 	end
 
-	-- Sets the current gear for an ACF gearbox
+	--- Sets the current gear for an ACF gearbox
+	-- @server
 	function ents_methods:acfShift ( gear )
 		checktype( self, ents_metatable )
 		checkluatype( gear, TYPE_NUMBER )
@@ -1467,7 +1514,8 @@ SF.AddHook("postload", function()
 		this:TriggerInput( "Gear", gear )
 	end
 
-	-- Cause an ACF gearbox to shift up
+	--- Cause an ACF gearbox to shift up
+	-- @server
 	function ents_methods:acfShiftUp ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1480,7 +1528,8 @@ SF.AddHook("postload", function()
 		this:TriggerInput( "Gear Up", 1 ) --doesn't need to be toggled off
 	end
 
-	-- Cause an ACF gearbox to shift down
+	--- Cause an ACF gearbox to shift down
+	-- @server
 	function ents_methods:acfShiftDown ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1493,7 +1542,8 @@ SF.AddHook("postload", function()
 		this:TriggerInput( "Gear Down", 1 ) --doesn't need to be toggled off
 	end
 
-	-- Sets the brakes for an ACF gearbox
+	--- Sets the brakes for an ACF gearbox
+	-- @server
 	function ents_methods:acfBrake ( brake )
 		checktype( self, ents_metatable )
 		checkluatype( brake, TYPE_NUMBER )
@@ -1507,7 +1557,8 @@ SF.AddHook("postload", function()
 		this:TriggerInput( "Brake", brake )
 	end
 
-	-- Sets the left brakes for an ACF gearbox
+	--- Sets the left brakes for an ACF gearbox
+	-- @server
 	function ents_methods:acfBrakeLeft ( brake )
 		checktype( self, ents_metatable )
 		checkluatype( brake, TYPE_NUMBER )
@@ -1522,7 +1573,8 @@ SF.AddHook("postload", function()
 		this:TriggerInput( "Left Brake", brake )
 	end
 
-	-- Sets the right brakes for an ACF gearbox
+	--- Sets the right brakes for an ACF gearbox
+	-- @server
 	function ents_methods:acfBrakeRight ( brake )
 		checktype( self, ents_metatable )
 		checkluatype( brake, TYPE_NUMBER )
@@ -1537,7 +1589,8 @@ SF.AddHook("postload", function()
 		this:TriggerInput("Right Brake", brake )
 	end
 
-	-- Sets the clutch for an ACF gearbox
+	--- Sets the clutch for an ACF gearbox
+	-- @server
 	function ents_methods:acfClutch ( clutch )
 		checktype( self, ents_metatable )
 		checkluatype( clutch, TYPE_NUMBER )
@@ -1551,7 +1604,8 @@ SF.AddHook("postload", function()
 		this:TriggerInput( "Clutch", clutch )
 	end
 
-	-- Sets the left clutch for an ACF gearbox
+	--- Sets the left clutch for an ACF gearbox
+	-- @server
 	function ents_methods:acfClutchLeft( clutch )
 		checktype( self, ents_metatable )
 		checkluatype( clutch, TYPE_NUMBER )
@@ -1566,7 +1620,8 @@ SF.AddHook("postload", function()
 		this:TriggerInput( "Left Clutch", clutch )
 	end
 
-	-- Sets the right clutch for an ACF gearbox
+	--- Sets the right clutch for an ACF gearbox
+	-- @server
 	function ents_methods:acfClutchRight ( clutch )
 		checktype( self, ents_metatable )
 		checkluatype( clutch, TYPE_NUMBER )
@@ -1581,7 +1636,8 @@ SF.AddHook("postload", function()
 		this:TriggerInput( "Right Clutch", clutch )
 	end
 
-	-- Sets the steer ratio for an ACF gearbox
+	--- Sets the steer ratio for an ACF gearbox
+	-- @server
 	function ents_methods:acfSteerRate ( rate )
 		checktype( self, ents_metatable )
 		checkluatype( rate, TYPE_NUMBER )
@@ -1596,7 +1652,8 @@ SF.AddHook("postload", function()
 		this:TriggerInput( "Steer Rate", rate )
 	end
 
-	-- Applies gear hold for an automatic ACF gearbox
+	--- Applies gear hold for an automatic ACF gearbox
+	-- @server
 	function ents_methods:acfHoldGear( hold )
 		checktype( self, ents_metatable )
 		checkluatype( hold, TYPE_NUMBER )
@@ -1611,7 +1668,8 @@ SF.AddHook("postload", function()
 		this:TriggerInput( "Hold Gear", hold )
 	end
 
-	-- Sets the shift point scaling for an automatic ACF gearbox
+	--- Sets the shift point scaling for an automatic ACF gearbox
+	-- @server
 	function ents_methods:acfShiftPointScale( scale )
 		checktype( self, ents_metatable )
 		checkluatype( scale, TYPE_NUMBER )
@@ -1629,7 +1687,8 @@ SF.AddHook("postload", function()
 
 	-- [ Gun Functions ] --
 
-	-- Returns true if the entity is an ACF gun
+	--- Returns true if the entity is an ACF gun
+	-- @server
 	function ents_methods:acfIsGun ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1639,7 +1698,8 @@ SF.AddHook("postload", function()
 		if isGun( this ) and not restrictInfo( this ) then return true else return false end
 	end
 
-	-- Returns true if the ACF gun is ready to fire
+	--- Returns true if the ACF gun is ready to fire
+	-- @server
 	function ents_methods:acfReady ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1652,7 +1712,8 @@ SF.AddHook("postload", function()
 		return false
 	end
 
-	-- Returns the magazine size for an ACF gun
+	--- Returns the magazine size for an ACF gun
+	-- @server
 	function ents_methods:acfMagSize ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1663,7 +1724,8 @@ SF.AddHook("postload", function()
 		return this.MagSize or 1
 	end
 
-	-- Returns the spread for an ACF gun or flechette ammo
+	--- Returns the spread for an ACF gun or flechette ammo
+	-- @server
 	function ents_methods:acfSpread ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1679,7 +1741,8 @@ SF.AddHook("postload", function()
 		return Spread
 	end
 
-	-- Returns true if an ACF gun is reloading
+	--- Returns true if an ACF gun is reloading
+	-- @server
 	function ents_methods:acfIsReloading ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1692,7 +1755,8 @@ SF.AddHook("postload", function()
 		return false
 	end
 
-	-- Returns the rate of fire of an acf gun
+	--- Returns the rate of fire of an acf gun
+	-- @server
 	function ents_methods:acfFireRate ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1703,7 +1767,8 @@ SF.AddHook("postload", function()
 		return math.Round( this.RateOfFire or 0, 3 )
 	end
 
-	-- Returns the number of rounds left in a magazine for an ACF gun
+	--- Returns the number of rounds left in a magazine for an ACF gun
+	-- @server
 	function ents_methods:acfMagRounds ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1719,7 +1784,8 @@ SF.AddHook("postload", function()
 		return 0
 	end
 
-	-- Sets the firing state of an ACF weapon
+	--- Sets the firing state of an ACF weapon
+	-- @server
 	function ents_methods:acfFire ( fire )
 		checktype( self, ents_metatable )
 		checkluatype( fire, TYPE_NUMBER )
@@ -1733,7 +1799,8 @@ SF.AddHook("postload", function()
 		this:TriggerInput( "Fire", fire )
 	end
 
-	-- Causes an ACF weapon to unload
+	--- Causes an ACF weapon to unload
+	-- @server
 	function ents_methods:acfUnload ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1746,7 +1813,8 @@ SF.AddHook("postload", function()
 		this:UnloadAmmo()
 	end
 
-	-- Causes an ACF weapon to reload
+	--- Causes an ACF weapon to reload
+	-- @server
 	function ents_methods:acfReload ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1759,7 +1827,8 @@ SF.AddHook("postload", function()
 		this.Reloading = true
 	end
 
-	--Returns the number of rounds in active ammo crates linked to an ACF weapon
+	--- Returns the number of rounds in active ammo crates linked to an ACF weapon
+	-- @server
 	function ents_methods:acfAmmoCount ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1777,7 +1846,8 @@ SF.AddHook("postload", function()
 		return Ammo
 	end
 
-	--Returns the number of rounds in all ammo crates linked to an ACF weapon
+	--- Returns the number of rounds in all ammo crates linked to an ACF weapon
+	-- @server
 	function ents_methods:acfTotalAmmoCount ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1795,7 +1865,8 @@ SF.AddHook("postload", function()
 		return Ammo
 	end
 
-	-- Returns time to next shot of an ACF weapon
+	--- Returns time to next shot of an ACF weapon
+	-- @server
 	function ents_methods:acfReloadTime ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1806,7 +1877,8 @@ SF.AddHook("postload", function()
 		return reloadTime( this )
 	end
 
-	-- Returns number between 0 and 1 which represents reloading progress of an ACF weapon. Useful for progress bars
+	--- Returns number between 0 and 1 which represents reloading progress of an ACF weapon. Useful for progress bars
+	-- @server
 	function ents_methods:acfReloadProgress ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1817,7 +1889,8 @@ SF.AddHook("postload", function()
 		return math.Clamp( 1 - (this.NextFire - CurTime()) / reloadTime( this ), 0, 1 )
 	end
 
-	-- Returns time it takes for an ACF weapon to reload magazine
+	--- Returns time it takes for an ACF weapon to reload magazine
+	-- @server
 	function ents_methods:acfMagReloadTime ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1830,7 +1903,8 @@ SF.AddHook("postload", function()
 
 	-- [ Ammo Functions ] --
 
-	-- Returns true if the entity is an ACF ammo crate
+	--- Returns true if the entity is an ACF ammo crate
+	-- @server
 	function ents_methods:acfIsAmmo ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1840,7 +1914,8 @@ SF.AddHook("postload", function()
 		return isAmmo( this ) and not restrictInfo( this )
 	end
 
-	-- Returns the rounds left in an acf ammo crate
+	--- Returns the rounds left in an acf ammo crate
+	-- @server
 	function ents_methods:acfRounds ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1852,7 +1927,8 @@ SF.AddHook("postload", function()
 		return this.Ammo or 0
 	end
 
-	-- Returns the type of weapon the ammo in an ACF ammo crate loads into
+	--- Returns the type of weapon the ammo in an ACF ammo crate loads into
+	-- @server
 	function ents_methods:acfRoundType () --cartridge?
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1865,7 +1941,8 @@ SF.AddHook("postload", function()
 		return this.RoundType or "" -- E2 uses this one now
 	end
 
-	-- Returns the type of ammo in a crate or gun
+	--- Returns the type of ammo in a crate or gun
+	-- @server
 	function ents_methods:acfAmmoType ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1877,7 +1954,8 @@ SF.AddHook("postload", function()
 		return this.BulletData[ "Type" ] or ""
 	end
 
-	-- Returns the caliber of an ammo or gun
+	--- Returns the caliber of an ammo or gun
+	-- @server
 	function ents_methods:acfCaliber ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1889,7 +1967,8 @@ SF.AddHook("postload", function()
 		return ( this.Caliber or 0 ) * 10
 	end
 
-	-- Returns the muzzle velocity of the ammo in a crate or gun
+	--- Returns the muzzle velocity of the ammo in a crate or gun
+	-- @server
 	function ents_methods:acfMuzzleVel ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1901,7 +1980,8 @@ SF.AddHook("postload", function()
 		return math.Round( ( this.BulletData[ "MuzzleVel" ] or 0 ) * ACF.VelScale, 3 )
 	end
 
-	-- Returns the mass of the projectile in a crate or gun
+	--- Returns the mass of the projectile in a crate or gun
+	-- @server
 	function ents_methods:acfProjectileMass ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1913,7 +1993,8 @@ SF.AddHook("postload", function()
 		return math.Round( this.BulletData[ "ProjMass" ] or 0, 3 )
 	end
 
-	-- Returns the number of projectiles in a flechette round
+	--- Returns the number of projectiles in a flechette round
+	-- @server
 	function ents_methods:acfFLSpikes ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1926,7 +2007,8 @@ SF.AddHook("postload", function()
 		return this.BulletData[ "Flechettes" ] or 0
 	end
 
-	-- Returns the mass of a single spike in a FL round in a crate or gun
+	--- Returns the mass of a single spike in a FL round in a crate or gun
+	-- @server
 	function ents_methods:acfFLSpikeMass ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1939,7 +2021,8 @@ SF.AddHook("postload", function()
 		return math.Round( this.BulletData[ "FlechetteMass" ] or 0, 3)
 	end
 
-	-- Returns the radius of the spikes in a flechette round in mm
+	--- Returns the radius of the spikes in a flechette round in mm
+	-- @server
 	function ents_methods:acfFLSpikeRadius ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1952,7 +2035,8 @@ SF.AddHook("postload", function()
 		return math.Round( ( this.BulletData[ "FlechetteRadius" ] or 0 ) * 10, 3)
 	end
 
-	-- Returns the penetration of an AP, APHE, or HEAT round
+	--- Returns the penetration of an AP, APHE, or HEAT round
+	-- @server
 	function ents_methods:acfPenetration ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -1991,7 +2075,8 @@ SF.AddHook("postload", function()
 		return 0
 	end
 
-	-- Returns the blast radius of an HE, APHE, or HEAT round
+	--- Returns the blast radius of an HE, APHE, or HEAT round
+	-- @server
 	function ents_methods:acfBlastRadius ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -2024,7 +2109,8 @@ SF.AddHook("postload", function()
 
 	-- [ Armor Functions ] --
 
-	-- Returns the current health of an entity
+	--- Returns the current health of an entity
+	-- @server
 	function ents_methods:acfPropHealth ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -2037,7 +2123,8 @@ SF.AddHook("postload", function()
 		return math.Round( this.ACF.Health or 0, 3 )
 	end
 
-	-- Returns the current armor of an entity
+	--- Returns the current armor of an entity
+	-- @server
 	function ents_methods:acfPropArmor ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -2050,7 +2137,8 @@ SF.AddHook("postload", function()
 		return math.Round( this.ACF.Armour or 0, 3 )
 	end
 
-	-- Returns the max health of an entity
+	--- Returns the max health of an entity
+	-- @server
 	function ents_methods:acfPropHealthMax ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -2063,7 +2151,8 @@ SF.AddHook("postload", function()
 		return math.Round( this.ACF.MaxHealth or 0, 3 )
 	end
 
-	-- Returns the max armor of an entity
+	--- Returns the max armor of an entity
+	-- @server
 	function ents_methods:acfPropArmorMax ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -2076,7 +2165,8 @@ SF.AddHook("postload", function()
 		return math.Round( this.ACF.MaxArmour or 0, 3 )
 	end
 
-	-- Returns the ductility of an entity
+	--- Returns the ductility of an entity
+	-- @server
 	function ents_methods:acfPropDuctility ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -2091,7 +2181,8 @@ SF.AddHook("postload", function()
 
 	-- [ Fuel Functions ] --
 
-	-- Returns true if the entity is an ACF fuel tank
+	--- Returns true if the entity is an ACF fuel tank
+	-- @server
 	function ents_methods:acfIsFuel ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -2101,7 +2192,8 @@ SF.AddHook("postload", function()
 		return isFuel( this ) and not restrictInfo( this )
 	end
 
-	-- Returns true if the current engine requires fuel to run
+	--- Returns true if the current engine requires fuel to run
+	-- @server
 	function ents_methods:acfFuelRequired ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -2113,7 +2205,8 @@ SF.AddHook("postload", function()
 		return ( this.RequiresFuel and true ) or false
 	end
 
-	-- Sets the ACF fuel tank refuel duty status, which supplies fuel to other fuel tanks
+	--- Sets the ACF fuel tank refuel duty status, which supplies fuel to other fuel tanks
+	-- @server
 	function ents_methods:acfRefuelDuty ( on )
 		checktype( self, ents_metatable )
 		checktype( on, "boolean" )
@@ -2127,7 +2220,8 @@ SF.AddHook("postload", function()
 		this:TriggerInput( "Refuel Duty", on )
 	end
 
-	-- Returns the remaining liters or kilowatt hours of fuel in an ACF fuel tank or engine
+	--- Returns the remaining liters or kilowatt hours of fuel in an ACF fuel tank or engine
+	-- @server
 	function ents_methods:acfFuel ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -2152,7 +2246,8 @@ SF.AddHook("postload", function()
 		return 0
 	end
 
-	-- Returns the amount of fuel in an ACF fuel tank or linked to engine as a percentage of capacity
+	--- Returns the amount of fuel in an ACF fuel tank or linked to engine as a percentage of capacity
+	-- @server
 	function ents_methods:acfFuelLevel ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -2181,7 +2276,8 @@ SF.AddHook("postload", function()
 		return 0
 	end
 
-	-- Returns the current fuel consumption in liters per minute or kilowatts of an engine
+	--- Returns the current fuel consumption in liters per minute or kilowatts of an engine
+	-- @server
 	function ents_methods:acfFuelUse ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )
@@ -2211,7 +2307,8 @@ SF.AddHook("postload", function()
 		return math.Round( Consumption, 3 )
 	end
 
-	-- Returns the peak fuel consumption in liters per minute or kilowatts of an engine at powerband max, for the current fuel type the engine is using
+	--- Returns the peak fuel consumption in liters per minute or kilowatts of an engine at powerband max, for the current fuel type the engine is using
+	-- @server
 	function ents_methods:acfPeakFuelUse ()
 		checktype( self, ents_metatable )
 		local this = unwrap( self )


### PR DESCRIPTION
- Fixed functions which would error duo to outdated type checks
- Added checks to entity methods if self is a valid entity
- Make use of the permission system
- Added Docs so the functions will show up in the old helper and syntax highlighting (not possible to make it show up in the new helper without replacing the helper url)
- Added privileges for the entity set methods and new creation functions
- Added ACF library
-- Moved infoRestricted to the library instead of as a entity method
-- Added dragDivisor and effectiveArmor functions
-- Added creation functions for Mobility, Gun, FuelTanks and Ammo
-- Added functions to get the specs of ACF components by id or name
-- Added functions to get a list of all ACF components by category

Example code demonstrating the create functions:
```lua
--@server

-- Mobility
local engine = acf.createMobility(chip():getPos() + Vector(0, 0, 50), Angle(), "3.3L-V4", true)
local gearbox = acf.createMobility(chip():getPos() + Vector(-50, 0, 45), Angle(0, 90, 0), "6-Speed, Inline, Small", true)
local fueltank = acf.createFuelTank(chip():getPos() + Vector(0, 0, 30), Angle(), "Tank_4x4x2", "Diesel", true)
local wheel = prop.create(chip():getPos() + Vector(-100, 0, 45), Angle(0, 90, 0), "models/sprops/trans/wheel_b/t_wheel30.mdl", false)

constraint.ballsocketadv(gearbox, wheel, 0, 0, gearbox:worldToLocal(wheel:getPos()), Vector(), 0, 0, Vector(-180, -0.1, -0.1), Vector(180, 0.1, 0.1), Vector(), false, false)

engine:acfLinkTo(gearbox)
engine:acfLinkTo(fueltank)
gearbox:acfLinkTo(wheel)

engine:acfSetActive(true)
engine:acfSetThrottle(100)
fueltank:acfSetActive(true)

--printTable(acf.getMobilitySpecs("3.3L-V4"))
-- Weaponry, on a timer because else we hit the burst limit
timer.simple(1, function()
    local gun = acf.createGun(chip():getPos() + Vector(100, 0, 50), Angle(), "100mm Cannon", true)
    local ammo = acf.createAmmo(chip():getPos() + Vector(100, 0, 30), Angle(), "Ammo2x4x4", "100mm Cannon", "HEAT", true, {
        -- Doesn't matter than we put high valus here, internally it will handle this and make sense of it somehow like in the acfmenu
        propellantLength = 10000,
        projectileLength = 10000,
        heFillerVolume = 10000,
        crushConeAngle = 10,
        tracer = true
    })
    
    gun:acfLinkTo(ammo)
    gun:acfFire(1)
    
    ammo:acfSetActive(true)
end)