### PR TITLE
make random sounds index a table.

### DIFF
--- a/lua/effects/acf_ap_penetration/init.lua
+++ b/lua/effects/acf_ap_penetration/init.lua
@@ -1,5 +1,13 @@
 local ACFEnts = list.Get("ACFEnts")
 local GunTable = ACFEnts["Guns"]
+
+--Not done programmatically in case of future sounds not being numerically incremented.
+local PenetrationSounds = {
+	"/acf_other/penetratingshots/00000292.wav",
+	"/acf_other/penetratingshots/00000293.wav",
+	"/acf_other/penetratingshots/00000294.wav",
+	"/acf_other/penetratingshots/00000295.wav",
+}
    
  /*--------------------------------------------------------- 
     Initializes the effect. The data is a table of data  
@@ -23,7 +31,7 @@ local GunTable = ACFEnts["Guns"]
 	local Impact = util.TraceLine(ImpactTr)					--Trace to see if it will hit anything
 	self.Normal = Impact.HitNormal
 	
-	sound.Play( "/acf_other/penetratingshots/0000029"..math.random(2,5)..".wav", Impact.HitPos, math.Clamp(self.Mass*200,65,500), math.Clamp(self.Velocity*0.01,25,255), 1 )
+	sound.Play( PenetrationSounds[math.random( #PenetrationSounds )], Impact.HitPos, math.Clamp(self.Mass*200,65,500), math.Clamp(self.Velocity*0.01,25,255), 1 )
 	
 	--self.Entity:EmitSound( "ambient/explosions/explode_1.wav" , 100 + self.Radius*10, 200 - self.Radius*10 )
 	

--- a/lua/effects/acf_ap_ricochet/init.lua
+++ b/lua/effects/acf_ap_ricochet/init.lua
@@ -1,4 +1,9 @@
-
+--Not done programmatically in case of future sounds not being numerically incremented.
+local RicochetSounds = {
+	"/acf_other/ricochets/00000320.wav",
+	"/acf_other/ricochets/00000321.wav",
+	"/acf_other/ricochets/00000322.wav",
+}
    
  /*--------------------------------------------------------- 
     Initializes the effect. The data is a table of data  
@@ -26,7 +31,7 @@
 		BulletEffect.Damage = 0	 
 	LocalPlayer():FireBullets(BulletEffect) 
 	
-	sound.Play( "/acf_other/ricochets/0000032"..math.random(0,2)..".wav", self.Origin, math.Clamp(self.Mass*200,65,500), math.Clamp(self.Velocity*0.01,25,255), 1 )
+	sound.Play( RicochetSounds[math.random( #RicochetSounds )], self.Origin, math.Clamp(self.Mass*200,65,500), math.Clamp(self.Velocity*0.01,25,255), 1 )
 	
 	util.Decal("ExplosiveGunshot", self.Origin + self.DirVec*10, self.Origin - self.DirVec*10)
 	

--- a/lua/entities/acf_engine.lua
+++ b/lua/entities/acf_engine.lua
@@ -664,12 +664,19 @@ function ENT:CheckRopes()
 	
 end
 
+--Not done programmatically in case of future sounds not being numerically incremented.
+local UnlinkSounds = {
+	"physics/metal/metal_box_impact_bullet1.wav",
+	"physics/metal/metal_box_impact_bullet2.wav",
+	"physics/metal/metal_box_impact_bullet3.wav",
+}
+
 --unlink fuel tanks out of range
 function ENT:CheckFuel()
 	for _,tank in pairs(self.FuelLink) do
 		if self:GetPos():Distance(tank:GetPos()) > 512 then
 			self:Unlink( tank )
-			soundstr =  "physics/metal/metal_box_impact_bullet" .. tostring(math.random(1, 3)) .. ".wav"
+			soundstr = UnlinkSounds[math.random( #UnlinkSounds )]
 			self:EmitSound(soundstr,500,100)
 		end
 	end

--- a/lua/entities/acf_gun.lua
+++ b/lua/entities/acf_gun.lua
@@ -448,6 +448,13 @@ local function RetDist( enta, entb )
 	return dist
 end
 
+--Not done programmatically in case of future sounds not being numerically incremented.
+local UnlinkSounds = {
+	"physics/metal/metal_box_impact_bullet1.wav",
+	"physics/metal/metal_box_impact_bullet2.wav",
+	"physics/metal/metal_box_impact_bullet3.wav",
+}
+
 function ENT:Think()
 	
 	if ACF.CurTime > self.NextLegalCheck then
@@ -491,7 +498,7 @@ function ENT:Think()
 					totalcap = totalcap + Crate.Capacity
 				else
 					self:Unlink( Crate )
-					soundstr =  "physics/metal/metal_box_impact_bullet" .. tostring(math.random(1, 3)) .. ".wav"
+					soundstr = UnlinkSounds[math.random( #UnlinkSounds )]
 					self:EmitSound(soundstr,500,100)
 				end
 			end

--- a/lua/weapons/torch/shared.lua
+++ b/lua/weapons/torch/shared.lua
@@ -37,17 +37,30 @@ SWEP.DrawCrosshair		= true
 
 
 
+local RepairSounds = {
+	"ambient/energy/NewSpark03.wav",
+	"ambient/energy/NewSpark04.wav",
+	"ambient/energy/NewSpark05.wav",
+}
+
+local ZapSounds = {
+	"weapons/physcannon/superphys_small_zap1.wav",
+	"weapons/physcannon/superphys_small_zap2.wav",
+	"weapons/physcannon/superphys_small_zap3.wav",
+	"weapons/physcannon/superphys_small_zap4.wav",
+}
+
 function SWEP:Initialize()
 	if ( SERVER ) then 
 		self:SetWeaponHoldType("pistol")--"357 hold type doesnt exist, it's the generic pistol one" Kaf
 	end
-	util.PrecacheSound( "ambient/energy/NewSpark03.wav" )
-	util.PrecacheSound( "ambient/energy/NewSpark04.wav" )
-	util.PrecacheSound( "ambient/energy/NewSpark05.wav" )
-	util.PrecacheSound( "weapons/physcannon/superphys_small_zap1.wav" )
-	util.PrecacheSound( "weapons/physcannon/superphys_small_zap2.wav" )
-	util.PrecacheSound( "weapons/physcannon/superphys_small_zap3.wav" )
-	util.PrecacheSound( "weapons/physcannon/superphys_small_zap4.wav" )
+
+	for i = 1, #RepairSounds do
+		util.PrecacheSound( RepairSounds[i] )
+	end
+	for i = 1, #ZapSounds do
+		util.PrecacheSound( ZapSounds[i] )
+	end
 	util.PrecacheSound( "items/medshot4.wav" )
 	
 	self.LastSend = 0
@@ -124,7 +137,7 @@ function SWEP:PrimaryAttack()
 			if ( Valid and ent.ACF.Health < ent.ACF.MaxHealth ) then
 				ent.ACF.Health = math.min(ent.ACF.Health + (30/ent.ACF.MaxArmour),ent.ACF.MaxHealth)
 				ent.ACF.Armour = ent.ACF.MaxArmour * (0.5 + ent.ACF.Health/ent.ACF.MaxHealth/2)
-				ent:EmitSound( "ambient/energy/NewSpark0" ..tostring( math.random( 3, 5 ) ).. ".wav", true, true )--Welding noise here, gotte figure out how to do a looped sound.
+				ent:EmitSound( RepairSounds[math.random( #RepairSounds )], true, true )--Welding noise here, gotte figure out how to do a looped sound.
 				TeslaSpark(tr.HitPos , 1 )
 			end
 			self.Weapon:SetNWFloat( "HP", ent.ACF.Health )
@@ -183,7 +196,7 @@ self.Weapon:SetNextPrimaryFire( CurTime() + 0.05 )
 				effectdata:SetStart( userid:GetShootPos() )
 				effectdata:SetOrigin( tr.HitPos )
 				util.Effect( "Sparks", effectdata , true , true )
-				ent:EmitSound( "weapons/physcannon/superphys_small_zap" ..tostring( math.random( 1, 4 ) ).. ".wav", true , true ) --old annoyinly loud sounds
+				ent:EmitSound( ZapSounds[math.random( #ZapSounds )], true , true ) --old annoyinly loud sounds
 			end
 		else 
 			self.Weapon:SetNWFloat( "HP", 0 )


### PR DESCRIPTION
fixes multiple pointless concatenations every time a sound is emitted.
also makes it easier to add new sounds, and in the torch swep removes partial duplicate string in util.PrecacheSound.
the comment was omitted from the torch because, since they are not added by acf, adding them to the table programmatically does not really have any disadvantage other than consistency.

this also helps for the unlikely use case of searching for sound file strings in ACF, i.e. to add them to a fastdl.