### PR TITLE
Localized accidental global variable

### DIFF
--- a/lua/entities/acf_gun.lua
+++ b/lua/entities/acf_gun.lua
@@ -629,7 +629,7 @@ function ENT:FireShell()
 	end
 
 	if ( bool and self.IsUnderWeight and self.Ready and self.Legal ) then
-		Blacklist = {}
+		local Blacklist = {}
 		if not ACF.AmmoBlacklist[self.BulletData.Type] then
 			Blacklist = {}
 		else


### PR DESCRIPTION
Everywhere else in the code base, `Blacklist` is a local variable. This one was accidentally made global.